### PR TITLE
Reviewed products

### DIFF
--- a/docs/products/api-server.md
+++ b/docs/products/api-server.md
@@ -5,7 +5,6 @@ reviewers: Dr Marcus Baw
 
 # dGC API Server
 
-
 {% set repository_name="rcpch/digital-growth-charts-server" -%}
 
 [![Github Issues](https://img.shields.io/github/issues/{{ repository_name }})](https://github.com/{{ repository_name }}/issues)
@@ -28,4 +27,4 @@ reviewers: Dr Marcus Baw
 
 ## Getting Started
 
-If you want to integrate the RCPCH Digital Growth Charts API into an application, then start [here](../integrator/getting-started.md)
+If you want to integrate the RCPCH Digital Growth Charts API into an application, then start [here](../integrator/getting-started.md).

--- a/docs/products/get-digital-growth-charts.md
+++ b/docs/products/get-digital-growth-charts.md
@@ -1,24 +1,28 @@
 ---
 title: Get Digital Growth Charts
-reviewers: Dr Marcus Baw
+reviewers: Dr Marcus Baw, Dr Anchit Chandran
 ---
 
 ## Paper growth charts holding up your digital transformation?
 
 We know from talking to experienced child health clinicians that they absolutely **must have** growth charts in any new digital solution. The lack of good quality and richly functional digital growth charts on the EPR/EHR market has held back digital transformation in many care settings. Some settings were forced to either hold up plans for digitisation, or use a parallel paper chart workflow.
 
-**We built the RCPCH Digital Growth Charts project to be a cost-effective, safe solution to that problem.**
+**We built the RCPCH Digital Growth Charts project to be a safe and cost-effective solution.**
 
 ## Trusted, familiar-looking Digital Growth Charts
 
-Produced and warranted by the RCPCH itself, the international authority on child health. Designed to be familiar to clinicians used to paper growth charts. And also richly functional, adding features like automatic gestational age correction, bone age, mid-parental height, event recording, and specialist references for Turner and Down syndromes.
+Produced and warranted by the RCPCH itself – the international authority on child health.
+
+Designed to be familiar to clinicians used to paper growth charts.
+
+Richly functional, adding features like automatic gestational age correction, bone age, mid-parental height, event recording, and specialist references for Turner and Down syndromes.
 
 ## The heavy lifting is done for you
 
-We know that calculation and display of growth parameters is technically hard, and comes with many clinical caveats. Our SaaS (Software As A Service) platform does all the hard work for you, meaning your clinicians get dependable, trustworthy charts, and digital transformation can proceed.
+We know that calculation and display of growth parameters is technically hard, and comes with many clinical caveats. Our SaaS *(Software As A Service)* platform does all the hard work for you, meaning your clinicians get dependable, trustworthy charts, and digital transformation can proceed.
 
 We think more stuff in the NHS should be done this way!
 
 ## Who's using the RCPCH Digital Growth Charts?
 
-Already in use in numerous NHS Trusts across England, the RCPCH Digital Growth Charts are also currently being adopted by UK General Practice clinical systems, at National level in UK Devolved Nations, and within major neonatal and maternity systems.
+The RCPCH Digital Growth Charts are already used in numerous NHS Trusts across England. Also, they are currently being adopted by UK General Practice clinical systems, at National level in UK Devolved Nations, and within major neonatal and maternity systems.

--- a/docs/products/pricing.md
+++ b/docs/products/pricing.md
@@ -1,15 +1,15 @@
 ---
 title: Pricing
-reviewers: Dr Marcus Baw, Dr Simon Chapman
+reviewers: Dr Marcus Baw, Dr Simon Chapman, Dr Anchit Chandran
 ---
 
 # Pricing and Commercial Information
 
 The RCPCH is a registered charity, and the Digital Growth Charts API's cost model is designed to ensure sustainable future maintenance and development of the Digital Growth Charts APIs. We also have a commitment to always provide a Free Tier to ensure rapid on-boarding and novel and exploratory uses.
 
-[The most up-to-date pricing and support information is on the RCPCH website](https://www.rcpch.ac.uk/resources/growth-charts/digital/about#subscriptions-and-pricing)
+[The most up-to-date pricing and support information is on the RCPCH website](https://www.rcpch.ac.uk/resources/growth-charts/digital/about#subscriptions-and-pricing).
 
-We have a range of options for API usage tiers and developer support, which we've developed to cater for a range of organisation sizes and requirements, however if you don't see what you need then please do [contact our Commercial team](../about/contact.md#commercial).
+We have a range of options for API usage tiers and developer support, which we've developed to cater for a range of organisational sizes and requirements, however if you don't see what you need then please do [contact our Commercial team](../about/contact.md#commercial).
 
 <p align="center">
   <a href="https://www.rcpch.ac.uk/resources/growth-charts/digital/about#subscriptions-and-pricing">

--- a/docs/products/products-overview.md
+++ b/docs/products/products-overview.md
@@ -1,6 +1,6 @@
 ---
 title: Products Overview
-reviewers: Dr Marcus Baw
+reviewers: Dr Marcus Baw, Dr Anchit Chandran
 ---
 
 # Products Overview
@@ -11,19 +11,24 @@ docs/_assets/_snippets/htn-award.md
 
 ## The RCPCH Digital Growth Charts (dGC) Platform
 
-It's important to understand the architecture of the Digital Growth Charts Platform. It is not built as a single 'app' or product, but for important reasons of interoperability and reusability of the code, it is split into functional units:
+It's important to understand the architecture of the Digital Growth Charts Platform. It is not built as a single 'app' or product. For important reasons of interoperability and reusability of the code, it is split into functional units:
 
 ### [The Digital Growth Charts API Server](../products/api-server.md)
 
-The **RCPCH Digital Growth Charts** (**RCPCH dGC**) platform centres around a 'backend' REST API which provides **calculated growth parameters** derived from **supplied child measurements** such as **height** and **weight**. It accepts growth data in a JSON format and returns Growth Chart Calculations in a JSON format, all over REST. The response from the API contains everything needed to display a graphical Growth Chart as well as many other parameters which are helpful to clinicians caring for children.
+The **RCPCH Digital Growth Charts** (**RCPCH dGC**) platform centres around a 'backend' REST API which provides **calculated growth parameters** derived from **supplied child measurements** such as **height** and **weight**. It accepts growth data in a JSON format and returns Growth Chart Calculations in a JSON format, all over REST. The response from the API contains everything needed to display a graphical Growth Chart, as well as many other parameters which are helpful to clinicians caring for children.
 
 ### [The React.js chart component](../products/react-component.md)
 
-This can be thought of as the complementary 'frontend' to the 'backend' server previously mentioned. It is designed as a React.js component library written in Typescript (a superset of Javascript), making it relatively easy to use in third-party applications, significantly reducing the work involved in displaying a standard chart. It can also be used as a 'template' to help implement charting in another programming language or framework. (The RCPCH can provide commercial support to aid in the development of charting in other languages and frameworks)
+This can be thought of as the complementary 'frontend' to the 'backend' server previously mentioned. It is designed as a React.js component library written in Typescript (a superset of Javascript), making it relatively easy to use in third-party applications, significantly reducing the work involved in displaying a standard chart. It can also be used as a 'template' to help implement charting in another programming language or framework.
+
+!!! info "Commercial Support"
+    The RCPCH can provide commercial support to aid in the development of charting in other languages and frameworks.
 
 ### [The Digital Growth Charts demonstration client](../products/react-client.md)
 
-This demo in React.js shows the main features of the API and serves as 'living documentation' of the standard chart view. It uses both the backend server and the frontend charting library and serves as a reference implementation which can assist with future implementations. You can see and test out the charts on our live demo site [growth.rcpch.ac.uk](https://growth.rcpch.ac.uk).
+This demo in React.js shows the main features of the API and serves as 'living documentation' of the standard chart view. It uses both the backend server and the frontend charting library, serving as a reference implementation, which can assist with future implementations.
+
+You can see and test out the charts on our live demo site: [growth.rcpch.ac.uk](https://growth.rcpch.ac.uk).
 
 ### [`rcpch-growth` Python package](../products/python-library.md)
 
@@ -31,11 +36,11 @@ This is the API 'calculation engine' extracted out of the API so that it can be 
 
 ### [The Digital Growth Charts command line utility](../products/command-line-client.md)
 
-This is a CLI which wraps the `rcpch-python` package and makes it easy to use the growth calculation functions of the python packages in the command line.
+This is a CLI which wraps the `rcpch-python` package. It makes it easy to use the growth calculation functions of the python packages in the command line.
 
 ### [Documentation](/)
 
-All documentation for the project is completely in the open and is primarily here on this documentation site. At present, a small amount of further documentation remains at the Azure API Managament Developer Portal at [dev.rcpch.ac.uk](https://dev.rcpch.ac.uk), however we are working to bring all documentation into this site.
+All documentation for the project is completely in the open and is primarily here on this documentation site. At present, a small amount of further documentation remains at the Azure API Management Developer Portal at [dev.rcpch.ac.uk](https://dev.rcpch.ac.uk), however we are working to bring all documentation into this site.
 
 ### [Clinical Safety documentation](../safety/overview.md)
 

--- a/docs/products/react-client.md
+++ b/docs/products/react-client.md
@@ -1,6 +1,6 @@
 ---
 title: React Demo Client
-reviewers: Dr Marcus Baw
+reviewers: Dr Marcus Baw, Dr Anchit Chandran
 ---
 
 # React Demo Client
@@ -21,9 +21,8 @@ reviewers: Dr Marcus Baw
 --8<--
 docs/_assets/_snippets/htn-award.md
 --8<--
- 
 
-This client, written in React.js, is for demonstration of the API and the chart library component. This is now the main focus of development for our RCPCH Digital Growth Charts Demo Client. We previously built a [Flask-based client](https://github.com/rcpch/digital-growth-charts-flask-client) (which used Flask only because that client actually split off from the original API development). The Flask client code is still available as an educational tool, however it is considered deprecated and will not recieve updates.
+This client, written in React.js, is for demonstration of the API and the chart library component. This is now the main focus of development for our RCPCH Digital Growth Charts Demo Client. We previously built a [Flask-based client](https://github.com/rcpch/digital-growth-charts-flask-client) (which used Flask only because that client actually split off from the original API development). The Flask client code is still available as an educational tool, however it is considered deprecated and will not receive updates.
 
 We have attempted to build the very best of growth chart theory and practice into the React client, including guidance given to us by the RCPCH Digital Growth Charts Project Board, and accepted best practice from the days of paper growth charts.
 
@@ -31,13 +30,13 @@ We have attempted to build the very best of growth chart theory and practice int
 
 ### Pink and Blue no longer used for the charts
 
-- It was felt that representing boys' charts with blue lines and girls' charts with pink lines did not really fit with 21st Century sensibilities of sex and gender. A Project Board decision was made to remove these colours and simply render the charts in monochrome black/grey, with some more off-the-wall colour themes available for variety and interest only.
+It was felt that representing boys' charts with blue lines and girls' charts with pink lines did not really fit with 21st Century sensibilities of sex and gender. A Project Board decision was made to remove these colours and simply render the charts in monochrome black/grey, with some more off-the-wall colour themes available for variety and interest only.
 
 ## Documentation
 
-- API documentation can be found [here](../integrator/api-reference.md) 
+API documentation can be found [here](../integrator/api-reference.md).
 
-- If you spot errors or inconsistencies in any documentation, please do point them out to us either by creating an Issue in the relevant repository, or by making a pull request with a fix. We will [acknowledge](../about/acknowledgements) all contributors.
+If you spot errors or inconsistencies in any documentation, please do point them out to us either by creating an Issue in the relevant repository, or by making a pull request with a fix. We will [acknowledge](../about/acknowledgements) all contributors.
 
 ## Developer documentation
 
@@ -54,7 +53,7 @@ Built in React using Semantic UI React.
 
 ### Style
 
-- We recommend the use of the Prettier Javascript linter
+We recommend the use of the Prettier Javascript linter.
 
 ## Other documentation
 

--- a/docs/products/react-component.md
+++ b/docs/products/react-component.md
@@ -1,6 +1,6 @@
 ---
 title: React Chart Component
-reviewers: Dr Marcus Baw, Dr Simon Chapman
+reviewers: Dr Marcus Baw, Dr Simon Chapman, Dr Anchit Chandran
 ---
 
 # React Chart Component
@@ -129,7 +129,7 @@ If the invalid hooks error persists, an alternative method is to add the followi
 
 ## Structure
 
-This library has been written in Typescript. The main component is `RCPCHChart`, which takes the following `props`. Note that each component will only render a single chart type, so if you wanted to render a weight *and* a height chart, these would be done as two separate instances of the component.
+This library has been written in Typescript. The main component is `RCPCHChart`, which takes the following `props`. Note that each component will only render a single chart type, so if you wanted to render a weight *and* a height chart, these must be done as two separate instances of the component.
 
 ### RCPCHChart component
 
@@ -165,7 +165,7 @@ This library has been written in Typescript. The main component is `RCPCHChart`,
 The `Measurement` interface is structured to reflect the JSON `Measurement` object which is returned by the API. The `RCPCHChart` component uses the `reference` prop to determine which chart to render. So far, 3 references are supported: UK-WHO, Turner Syndrome and Down Syndrome. The reference data for the centiles are included in the library in plottable format in the `chartdata` folder.
 
 !!! tip
-    This means in practice that you get the returned JSON from the dGC API and pass it directly in to the component and the component 'knows' how to render this correctly. You don't need to parse, restructure, or even understand the JSON returned from the API, just pass it directly to the component inside an array containing one `Measurement` object.
+    In practice, this means you get the returned JSON from the dGC API, passing it directly in to the component. The component 'knows' how to render this correctly. You don't need to parse, restructure, or even understand the JSON returned from the API: just pass it directly to the component inside an array containing one `Measurement` object.
 
 The `Measurement` interface structure is:
 
@@ -300,8 +300,7 @@ The `Measurement` interface structure is:
     }
     ```
 
-The styling components allow the user to customise elements of the chart:
-Chart styles control the chart and the tooltips
+The styling components allow the user to customise elements of the chart. Chart styles control the chart and the tooltips.
 
 ??? note "Styling options available through `ChartStyle`"
     ```js
@@ -369,7 +368,7 @@ Note for the tooltips and infobox text sizes, these are strokeWidths, not point 
 
 ### SDS Styles
 
-SDS styles control the colour and width of the SDS lines. Because all measurement methods are rendered on a single chart, the user is offered the option of different colours for each measurement method [height, weight, head circumference(ofc) and body mass index (bmi)]. If no SDS style is supplied, the centile line colour is used with an opacity applied to each measurement.
+SDS styles control the colour and width of the SDS lines. As all measurement methods are rendered on a single chart, the user is offered the option of different colours for each measurement method (height, weight, head circumference(OFC) and body mass index (BMI)). If no SDS style is supplied, the centile line colour is used with an opacity applied to each measurement.
 
 ??? note "SDS Styles"
     ```js
@@ -384,12 +383,12 @@ SDS styles control the colour and width of the SDS lines. Because all measuremen
 
 ### Measurement Styles
 
-Measurement styles control the plotted data points - colour, size and shape. Corrected ages are always rendered as crosses. Circles for chronological ages are preferred. On the SDS charts, measurement points are grey by default, with the measurement method in focus highlighted by rendering as a line. Points which are not highlighted can be emphasised on mouse hover, the highlighted colour being set by the highlightedMeasurementFill prop.
+Measurement styles control the plotted data points: colour, size and shape. Corrected ages are always rendered as crosses. Circles for chronological ages are preferred. On the SDS charts, measurement points are grey by default, with the measurement method in focus highlighted by rendering as a line. Points which are not highlighted can be emphasised on mouse hover, with the highlighted colour being set by the `highlightedMeasurementFill` prop.
 
 ??? note "Measurement Styles"
     ```js
     interface MeasurementStyle{
-        measurementFill?: string, 
+        measurementFill?: string,
         highLightedMeasurementFill?: string;
     }
     ```
@@ -412,7 +411,7 @@ Measurement styles control the plotted data points - colour, size and shape. Cor
     }
     ```
 
-This returns a midparental height as well as the midparental SDS and centile, and the centile data should the user which to plot a midparental centile unto the chart. The structure of the Reference and Centile interfaces is:
+This returns a mid-parental height, mid-parental SDS and centile, along with the centile data if the user wishes to plot a mid-parental centile. The structure of the Reference and Centile interfaces is:
 
 ??? note "`Reference` and `Centile` interface structures"
     ```js
@@ -457,35 +456,34 @@ Centile data are returned from the RCPCH API in this same structure, though no A
 
 ### `enableExport`
 
-```enableExport```: a boolean optional prop. If true, a copy/paste button is rendered below the chart. It defaults to false. If true, ```exportChartCallback``` must also be implemented.
+```enableExport```: a boolean optional prop, defaults to false. If true, ```exportChartCallback``` must be implemented and a copy-paste button is rendered below the chart.
 
 ### `exportChartCallBack`
 
-```exportChartCallback```: callback function implemented if enableExport is true. It receives an SVG element. This can be saved in the client to clipboard by converting to canvas using HTML5. An example implementation of this is [here](https://github.com/rcpch/digital-growth-charts-react-client/blob/live/src/functions/canvasFromSVG.js) in our demo client.
+```exportChartCallback``` callback function implemented if `enableExport` is true. It receives an SVG element. This can be saved in the client to clipboard by converting to canvas using HTML5. An example implementation of this is [here](https://github.com/rcpch/digital-growth-charts-react-client/blob/live/src/functions/canvasFromSVG.js) in our demo client.
 
 ### `clinicianFocus`
 
-```clinicianFocus```: a boolean optional prop which defaults to false. If true, the advice strings that are reported to users in tooltips are more technical and aimed at clinicians familiar with centile charts. If this prop is false then the advice strings will be less technical and more suitable for parents, guardians, carers or other laypersons.
+```clinicianFocus```: a boolean optional prop which defaults to false. If true, the advice strings that are reported to users in tooltips are more technical and aimed at clinicians familiar with centile charts. If false, the advice strings will be less technical and more suitable for parents, guardians, carers or other laypersons.
 
 !!! example "Requests for additional functionality in props"
-    In time more props can be added if users request them. If you have requests, please post issues on our [GitHub](https://github.com/rcpch/digital-growth-charts-react-component-library/issues) or get involved to contribute as below.
+    In time, more props can be added if users request them. If you have requests, please post issues on our [GitHub](https://github.com/rcpch/digital-growth-charts-react-component-library/issues) or get involved to contribute as below.
 
 ## Contributing
 
-see [Contributing](../developer/contributing.md) for information on how to get involved in the project.
+See [Contributing](../developer/contributing.md) for information on how to get involved in the project.
 
-You can get in touch with the primary developers to talk about the project using any of the methods on our [contact page](../about/contact.md)
+You can get in touch with the primary developers to talk about the project using any of the methods on our [contact page](../about/contact.md).
 
 ## Acknowledgements
 
 This Typescript library was built from the starter created by [Harvey Delaney](https://blog.harveydelaney.com/creating-your-own-react-component-library/)
 
-The charts are built using [Victory Charts](https://formidable.com/open-source/victory/docs/victory-chart/) for React. We tried several different chart packages for React, but we chose Victory because of their documentation and their ability to customise components.
-
+The charts are built using [Victory Charts](https://formidable.com/open-source/victory/docs/victory-chart/) for React. We tried several chart packages for React, but we chose Victory because of their documentation and their ability to customise components.
 
 ## Licensing
 
-The chart data bundled in the component is subject to copyright and is owned by the RCPCH. If you wish to use this software commercially, please [contact the RCPCH](../about/contact.md) so that we can ensure you have the correct license for use.
+The chart data bundled in the component is subject to copyright and is owned by the RCPCH. If you wish to use this software commercially, please [contact the RCPCH](../about/contact.md) so we can ensure you have the correct license for use.
 
-This chart component software is released under the MIT licence
+This chart component software is released under the MIT license.
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)

--- a/docs/products/react-component.md
+++ b/docs/products/react-component.md
@@ -18,14 +18,6 @@ reviewers: Dr Marcus Baw, Dr Simon Chapman
 
 :material-web: [Demo](https://growth.rcpch.ac.uk/)
 
-Although the process of obtaining a centile/SDS result from the API is very straightforward, rendering this to an actual digital growth chart graphic is quite complex. For example, charts typically have 9 main centile lines (though there are other formats), each of which can be rendered as a series. However the UK-WHO chart is made of several growth references, each from different datasets, and it is a stipulation that they must not overlap - this means for the four datasets which make up UK-WHO, the developer must render 36 separate 'sections' of centile lines correctly.
-
-Even then, there are certain rules which are key, published by the RCPCH project board. These relate to usability of the charts. For example, the 50th centile should be de-emphasised. These and other rules are listed on the [RCPCH Github](https://github.com/rcpch)
-
-Given the complexity, we decided to create a React component library for developers to use. We designed it to be customisable for those that wanted to use it, but also as a demonstration for developers who wanted to build the charts themselves from the ground up.
-
-For this reason, we have produced a permissively-licensed open-source React component, which aims to simplify the process of creating a chart from the chart data received from the API. It makes the job of drawing a vector-graphic centile chart much easier.
-
 ![height-chart-girl-component](../_assets/_images/height-chart-girl-component.png)
 
 You can use the component as-is in a React app, or include it in plain HTML or any other JavaScript framework.
@@ -36,7 +28,7 @@ You can use the component as-is in a React app, or include it in plain HTML or a
 * Zoom with zoom reset (optional prop)
 * Event logging - events associated with measurements
 * Bone ages
-* Midparental heights with midparental centile lines (at +2 and -2 SDS)
+* Mid-parental heights with mid-parental centile lines (at +2 and -2 SDS)
 
 ### Version 6 new features
 
@@ -48,20 +40,22 @@ You can use the component as-is in a React app, or include it in plain HTML or a
 ### New in 6.1
 
 * Dates included in tooltips
-* clinicianFocus (optional prop) to toggle between advice strings aimed at clinicians or those aimed at families/children & young people
-* toggle button to allow user to constrain viewable chart to measurements or view the whole chart
+* `clinicianFocus` (optional prop) to toggle between advice strings aimed at clinicians or those aimed at families / children & young people
+* Toggle button to allow user to constrain viewable chart to measurements or view the whole chart
 
 ## Background
 
 ### Why a Chart library?
 
-In the process of building the API, we realised that it would not be easy for developers not familiar with growth charts to produce a growth chart that is acceptable to clinicians. Even if the API were to send ato a chart remains complicated.
+In the process of building the API, we realised that it would not be easy for developers unfamiliar with growth charts to produce one that is acceptable to clinicians.
 
 For example, charts typically have 9 main centile lines (though there are other formats), each of which can be rendered as a series. However the UK-WHO chart is made of several growth references, each from different datasets, and it is a stipulation that they must not overlap - this means that for the four datasets which make up UK-WHO, the developer must render 36 separate 'sections' of centile lines, marrying them up correctly.
 
 Even then, there are certain rules which are key, published by the RCPCH project board. These relate to usability of the charts. For example, the 50th centile should be de-emphasised. These and other rules are listed on the [Client Specification](../integrator/client-specification.md)
 
-Given the above, we decided to create a React component library for developers to use. We designed it to be customisable for those that wanted to use it, but also as a demonstration for developers who wanted to build the charts themselves from the ground up, using the React component as a reference implementation.
+Given the complexity, we decided to create a React component library for developers to use. We designed it to be customisable for direct use, but also as a demonstration for developers wanting to build the charts from the ground up.
+
+For this reason, we have produced a permissively-licensed, open-source React component, which aims to simplify the process of creating a chart from the chart data received from the API. It makes the job of drawing a vector-graphic centile chart much easier.
 
 If you want to see how the library is implemented, we have built a full client for the RCPCHGrowth API in React, which uses this component library, and can be found [here](https://github.com/rcpch/digital-growth-charts-react-client).
 

--- a/docs/products/react-component.md
+++ b/docs/products/react-component.md
@@ -47,11 +47,11 @@ You can use the component as-is in a React app, or include it in plain HTML or a
 
 ### Why a Chart library?
 
-In the process of building the API, we realised that it would not be easy for developers unfamiliar with growth charts to produce one that is acceptable to clinicians.
+In the process of building the API, we realised the difficulty for developers unfamiliar with growth charts to produce one acceptable to clinicians.
 
-For example, charts typically have 9 main centile lines (though there are other formats), each of which can be rendered as a series. However the UK-WHO chart is made of several growth references, each from different datasets, and it is a stipulation that they must not overlap - this means that for the four datasets which make up UK-WHO, the developer must render 36 separate 'sections' of centile lines, marrying them up correctly.
+For example, charts typically have 9 main centile lines (though there are other formats), each of which can be rendered as a series. However, the UK-WHO chart is made of several growth references, each from different datasets, and it is a stipulation that they must not overlap. This means that for the four datasets which make up UK-WHO, the developer must render 36 separate 'sections' of centile lines, marrying them up correctly.
 
-Even then, there are certain rules which are key, published by the RCPCH project board. These relate to usability of the charts. For example, the 50th centile should be de-emphasised. These and other rules are listed on the [Client Specification](../integrator/client-specification.md)
+Even then, there are certain rules which are key, published by the RCPCH project board. These relate to usability of the charts. For example, the 50th centile should be de-emphasised. These and other rules are listed on the [Client Specification](../integrator/client-specification.md).
 
 Given the complexity, we decided to create a React component library for developers to use. We designed it to be customisable for direct use, but also as a demonstration for developers wanting to build the charts from the ground up.
 
@@ -61,27 +61,33 @@ If you want to see how the library is implemented, we have built a full client f
 
 ### Why use React?
 
-React is a popular UI library for Javascript. It has endured well and seems like a popular choice for developers. Importantly, unlike some other Javascript frameworks which are primarily designed for Single Page Applications, React doesn't expect to have the entire webpage to itself. It can be used as a small component in any other web page, even if the main framework being used is something completely different.
+React is a popular UI library for Javascript. It has endured well and seems like a popular choice for developers. Importantly, unlike some other Javascript frameworks which are primarily designed for Single Page Applications, React doesn't expect to have the entire webpage to itself. It can be used as a small component in any other web page, even if the main framework being used is completely different.
 
 !!! question "Tell us what you think"
-    Let us know what you think of our design decisions, on this or any other area of the dGC Project, by chatting to us on our [dGC Forum](https://openhealthhub.org/c/rcpch-digital-growth-charts/) :fontawesome-brands-discourse:
+    Let us know what you think of our design decisions, on this or any other area of the dGC Project, by chatting to us on our [dGC Forum](https://openhealthhub.org/c/rcpch-digital-growth-charts/) :fontawesome-brands-discourse:.
 
 ### What about other frameworks/UI libraries?
 
-If you need us to develop a charting component in a different language or framework, we may be able to do this with you or your company, however we would need to discuss the requirements and quote for this service. You should be aware that all such RCPCH-developed artefacts will also be open source. We will of course ensure that the licensing of such open source components is compatible with commercial use.
+If you need us to develop a charting component in a different language or framework, we may be able to do this with you or your company. We would need to discuss the requirements and quote for this service. You should be aware that all such RCPCH-developed artefacts will also be open source. We ensure the licensing of open source components is compatible with commercial use.
 
 !!! note "Contact us"
-    To contact us for this service, email <mailto:commercial@rcpch.ac.uk>
+    To contact us for this service, email <mailto:commercial@rcpch.ac.uk>.
 
 ## Getting started
 
 ```console
-foobar:~foo$ npm i --save @rcpch/digital-growth-charts-react-component-library
+npm i --save @rcpch/digital-growth-charts-react-component-library
 ```
 
-Victory Charts are a dependency (see below), themselves built on top of D3.js. On build, it is likely you will get an error relating to circular dependencies for some files in the d3-interpolate module. The is an issue logged [here](https://github.com/d3/d3-interpolate/issues/58).
+### Circular import errors
 
-If you want to run the package locally alongside the react client, there are some extra steps to go through. Since the chart library and the react client both use react, the charts will throw an error if you import them in the ```package.json``` of your app from a folder on your local machine. For example in your react app:
+Victory Charts are a dependency (see below), built on top of D3.js. On build, it is likely you will get an error relating to circular dependencies for some files in the d3-interpolate module. This issue is logged [here](https://github.com/d3/d3-interpolate/issues/58).
+
+### Running the Charts Package locally
+
+To run the package locally alongside the React client, there are some extra steps. Since the Chart library and the React client both use React, the Charts will throw an error if you import them in the ```package.json``` of your app from a folder on your local machine.
+
+For example, in your React app:
 
 ```json
 "dependencies": {
@@ -89,29 +95,30 @@ If you want to run the package locally alongside the react client, there are som
 } 
 ```
 
-The problem with this is that there are then 2 versions of react running. To overcome this, in your application:
+This causes a problem as it leads to 2 versions of React running. To overcome this, in your application:
 
 ```console
-foobar:~foo$ cd node_modules/react
-foobar:~foo$ npm link
+cd node_modules/react
+npm link
 ```
 
-In the root folder of your chart library:
+In the root folder of your Chart library:
 
 ```console
-foobar:~foo$ npm link react
+npm link react
 ```
 
-Repeat the same for ```react-dom``` ensuring all the package versions are the same for your app and the library. The library currently uses version 17.0.2 of react and react-dom.
-In this way, you can make changes to the chart package and they will appear in your app after:
+Repeat the same for ```react-dom``` ensuring all the package versions are the same for your app and the library. The library currently uses version `17.0.2` of React and React-dom.
+
+Now, you can view your changes made live in your app:
 
 ```console
-foobar:~foo$ npm run build
+npm run build
 ```
 
-The refresh your app.
+Refresh your app.
 
-If the invalid hooks error persists inspite of this, an alternative is to add the following line to ```package.json``` in the library. This removes the node_modules from the build folder.
+If the invalid hooks error persists, an alternative method is to add the following line to ```package.json``` in the library. This removes the node_modules from the build folder:
 
 ```json
 "scripts": {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -106,11 +106,11 @@ theme:
   logo: _assets/_images/rcpch_logo.png
 
 plugins:
-  - git-committers:
-      repository: rcpch/digital-growth-charts-documentation
-      branch: live
-  - git-revision-date-localized:
-      enable_creation_date: true
+  # - git-committers:
+  #     repository: rcpch/digital-growth-charts-documentation
+  #     branch: live
+  # - git-revision-date-localized:
+  #     enable_creation_date: true
   - macros
   - search
   - render_swagger


### PR DESCRIPTION
Only minor changes with typo's / wording

- In [commit b930e33](https://github.com/rcpch/digital-growth-charts-documentation/commit/b930e33d294592fac3d33a3ae375cfdb2e690cb3) I removed the `foobar:~foo$` from shell commands to make it more Operating System agnostic - I'm assuming that just denotes essentially the username? As on Windows cmd, it just shows the current working directory