### PR TITLE
Material for MkDocs 9.1 upgrade

### DIFF
--- a/.github/workflows/build-and-deploy-to-gh-pages-and-azure.yml
+++ b/.github/workflows/build-and-deploy-to-gh-pages-and-azure.yml
@@ -13,7 +13,8 @@ jobs:
   build-and-deploy-to-gh-pages:
     runs-on: ubuntu-latest
     env:
-      ENABLE_PDF_EXPORT: True
+      ENABLE_PDF_EXPORT: True # Makes PDF export an option, default disabled, when building locally
+      ENABLE_GIT_COMMITTERS: True # Makes git-committers an option, default disabled, when building locally
     steps:
       - uses: actions/checkout@v2
         with:

--- a/docs/developer/writing-documentation.md
+++ b/docs/developer/writing-documentation.md
@@ -7,7 +7,7 @@ reviewers: Dr Marcus Baw, Dr Anchit Chandran
 
 Where possible, we have tried to bring together **all** documentation relating to any aspect of the project into this one MkDocs site, published at [growth.rcpch.ac.uk](https://growth.rcpch.ac.uk)
 
-## MkDocs
+## Material for MkDocs
 
 The documentation for the Digital Growth Charts project is created using the MkDocs documentation framework. It uses the '*Material for MkDocs*' theme, which adds a number of extra features and a more modern appearance. We use the *Material for MkDocs Insiders* edition, allowing us to support the project, whilst getting a few neat early-access features.
 
@@ -55,6 +55,7 @@ pyenv virtualenv 3.10.2 mkdocs
 Install Material for MKDocs and other dependencies:
 
 ```console
+pip install git+https://<INSERT_GH_TOKEN_HERE>@github.com/squidfunk/mkdocs-material-insiders.git
 pip install -r requirements.txt
 ```
 
@@ -65,6 +66,17 @@ mkdocs serve
 ```
 
 MkDocs will tell you what URL you can view the site on, which is usually `localhost:8000`. You can vary this in the settings, if port `8000` is already in use.
+
+#### `git-committers` and `mkdocs-with-pdf` plugins
+
+These plugins can add 10-15 seconds of build time to the site, so when developing locally, they are disabled by default. They are enabled by using environment variables, if you want to test that they work locally before pushing to the remote:
+
+```console
+export ENABLE_GIT_COMMITTERS=true; mkdocs serve
+export ENABLE_PDF_EXPORT=true; mkdocs serve
+```
+
+You should always build the site at least once with both PDF export and Git Committers enabled, to ensure there are no issues, before pushing to the remote.
 
 #### Notes
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -88,10 +88,12 @@ theme:
   name: material
   custom_dir: rcpch-theme
   features:
+    - content.action.edit # explicitly adds edit button (Material4MkDocs9.0) 
+    - content.action.view # explicitly adds view button (Material4MkDocs9.0) 
     - content.code.copy
     - content.code.select
     - navigation.expand
-    - navigation.footer
+    - navigation.footer # explicitly adds footer prev/next (Material4MkDocs9.0) 
     - navigation.instant
     - navigation.tabs
     - navigation.tabs.sticky
@@ -115,6 +117,7 @@ plugins:
   - git-committers:
       repository: rcpch/digital-growth-charts-documentation
       branch: live
+      enabled: !ENV [ENABLE_GIT_COMMITTERS, false] # makes Git Committers optional
   - git-revision-date-localized:
       enable_creation_date: true
   - macros

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,20 @@
 # requirements for the dGC documentation
 
-# this installs Material for MkDocs and all dependencies
-mkdocs-material
+# **** MATERIAL FOR MKDOCS INSIDERS ****
+# IMPORTANT: This project uses Material for MkDocs **Insiders** Edition.
+# To install this you will need a GitHub token which is available (for RCPCH team only)
+# from Marcus Baw (pacharanero).
+# If you have the token, you can manually run this command to install Insiders:
+# pip install git+https://<INSERT_GH_TOKEN_HERE>@github.com/squidfunk/mkdocs-material-insiders.git
+# Further information is at https://squidfunk.github.io/mkdocs-material/insiders/getting-started/
+# In production/deployment, the relevant GitHub workflow has access to the token.
+
+# **** MATERIAL FOR MKDOCS ****
+# In a situation where you need to run the documentation site locally but can't
+# get access to the GitHub token, you can uncomment the line below to access the normal version.
+# Most things will work fine, but some features will be disabled:
+
+# mkdocs-material
 
 # for the APIspec page at {{baseurl}}/integrator/api-reference/
 mkdocs-render-swagger-plugin


### PR DESCRIPTION
* makes it clearer what requirements.txt will and won't do in terms of installing Insiders edition
* Makes git-committers default disabled when building locally
* reactivates some features which are now 'opt-in' in 9.1
* more explanatory comments in mkdocs.yml and GH actions
* documents the above