### PR TITLE
Update build to remove mkdocs insiders

### DIFF
--- a/.github/workflows/ALL-BRANCHES-ALL-PRs-build-and-deploy-to-azure.yml
+++ b/.github/workflows/ALL-BRANCHES-ALL-PRs-build-and-deploy-to-azure.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.11'
-      - run: pip install git+https://${{ secrets.MATERIAL_FOR_MKDOCS_ACCESS_TOKEN }}@github.com/squidfunk/mkdocs-material-insiders.git
+      #- run: pip install git+https://${{ secrets.MATERIAL_FOR_MKDOCS_ACCESS_TOKEN }}@github.com/squidfunk/mkdocs-material-insiders.git
       - run: pip install -r requirements.txt
       - run: mkdocs build
       - name: Upload to Azure

--- a/.github/workflows/ALL-BRANCHES-ALL-PRs-build-and-deploy-to-azure.yml
+++ b/.github/workflows/ALL-BRANCHES-ALL-PRs-build-and-deploy-to-azure.yml
@@ -14,6 +14,7 @@ on:
     types: [opened, synchronize, reopened, closed]
     branches:
       - live
+  workflow_dispatch:
 permissions:
   contents: write
   pull-requests: write # this permission is required in order to allow PR comment with staging URL

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -164,18 +164,18 @@ markdown_extensions:
   - admonition
   - attr_list
   - md_in_html #insiders
-  #- pymdownx.details
-  # - pymdownx.emoji:
-  #     emoji_generator: !!python/name:materialx.emoji.to_svg
-  #     emoji_index: !!python/name:materialx.emoji.twemoji
-  #- pymdownx.highlight
-  #- pymdownx.inlinehilite
-  #- pymdownx.keys
-  # - pymdownx.snippets:
-  #     check_paths: true
-  #     auto_append:
-  #       - includes/_abbreviations.md # adds abbreviations snippets to ALL pages
-  #- pymdownx.superfences
+  - pymdownx.details
+  - pymdownx.emoji:
+      emoji_generator: !!python/name:materialx.emoji.to_svg
+      emoji_index: !!python/name:materialx.emoji.twemoji
+  - pymdownx.highlight
+  - pymdownx.inlinehilite
+  - pymdownx.keys
+  - pymdownx.snippets:
+      check_paths: true
+      auto_append:
+        - includes/_abbreviations.md # adds abbreviations snippets to ALL pages
+  - pymdownx.superfences
   - toc:
       permalink: false
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -165,9 +165,9 @@ markdown_extensions:
   - attr_list
   - md_in_html #insiders
   - pymdownx.details
-  - pymdownx.emoji:
-      emoji_generator: !!python/name:materialx.emoji.to_svg
-      emoji_index: !!python/name:materialx.emoji.twemoji
+  # - pymdownx.emoji:
+  #     emoji_generator: !!python/name:materialx.emoji.to_svg
+  #     emoji_index: !!python/name:materialx.emoji.twemoji
   - pymdownx.highlight
   - pymdownx.inlinehilite
   - pymdownx.keys

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -164,18 +164,18 @@ markdown_extensions:
   - admonition
   - attr_list
   - md_in_html #insiders
-  - pymdownx.details
+  #- pymdownx.details
   # - pymdownx.emoji:
   #     emoji_generator: !!python/name:materialx.emoji.to_svg
   #     emoji_index: !!python/name:materialx.emoji.twemoji
-  - pymdownx.highlight
-  - pymdownx.inlinehilite
-  - pymdownx.keys
-  - pymdownx.snippets:
-      check_paths: true
-      auto_append:
-        - includes/_abbreviations.md # adds abbreviations snippets to ALL pages
-  - pymdownx.superfences
+  #- pymdownx.highlight
+  #- pymdownx.inlinehilite
+  #- pymdownx.keys
+  # - pymdownx.snippets:
+  #     check_paths: true
+  #     auto_append:
+  #       - includes/_abbreviations.md # adds abbreviations snippets to ALL pages
+  #- pymdownx.superfences
   - toc:
       permalink: false
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@
 # get access to the GitHub token, you can uncomment the line below to access the normal version.
 # Most things will work fine, but some features will be disabled:
 
-# mkdocs-material
+mkdocs-material
 
 # for the APIspec page at {{baseurl}}/integrator/api-reference/
 mkdocs-render-swagger-plugin


### PR DESCRIPTION
Allows us to deploy the site again as I think the mkdocs insiders PAT had expired