### PR TITLE
Fix Swagger UI by bumping version

### DIFF
--- a/docs/integrator/api-reference.md
+++ b/docs/integrator/api-reference.md
@@ -6,11 +6,11 @@ audience: integrators, implementers, technical-architects
 # API Reference
 
 <!-- Embeds the Swagger UI view of the API reference here -->
-<link type="text/css" rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@3/swagger-ui.css">
+<link type="text/css" rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@5/swagger-ui.css">
 
 <div id="swagger-ui"></div>
 
-<script src="https://unpkg.com/swagger-ui-dist@3/swagger-ui-bundle.js" charset="UTF-8"></script>
+<script src="https://unpkg.com/swagger-ui-dist@5/swagger-ui-bundle.js" charset="UTF-8"></script>
 
 <script>
     const ui = SwaggerUIBundle({


### PR DESCRIPTION
Error on https://growth.rcpch.ac.uk/integrator/api-reference/ at the moment:

Unable to render this definition

The provided definition does not specify a valid version field.

Please indicate a valid Swagger or OpenAPI version field. Supported version fields are swagger: "2.0" and those that match openapi: 3.0.n (for example, openapi: 3.0.0).