### PR TITLE
Fix typo in LMS formula

### DIFF
--- a/docs/clinician/how-the-api-works.md
+++ b/docs/clinician/how-the-api-works.md
@@ -23,7 +23,7 @@ The LMS method provides a way of obtaining normalised growth centiles from a ref
 
 - To obtain the z-score, plug the LMS values with the child's measurement into the formula:
   <div class="latex">
-  <img src="https://latex.codecogs.com/svg.image?z=((measure/M)^L)-1/(L/S))"></img>
+  <img src="https://latex.codecogs.com/svg.image?z=\frac{(measurement / M)^L -1}{LS}"></img>
   </div>
 
 ## Growth References


### PR DESCRIPTION
Copy across the fix for the formula from https://github.com/rcpch/digital-growth-charts-server/pull/209 so we can update the docs before they are merged into the main repo.

Acknowledging this was reported by various clinicians not on GitHub to tag! Thank you all for reviewing the documentation