### PR TITLE
Remove the link to the signal group

### DIFF
--- a/docs/about/contact.md
+++ b/docs/about/contact.md
@@ -16,14 +16,6 @@ audience: all
 
     [RCPCH Forum :fontawesome-brands-discourse:](https://forum.rcpch.tech){ .md-button .md-button--primary }
 
-!!! info "Signal Chat"
-
-    We have an RCPCH Developers Signal chat group for instant message support of the RCPCH dGC project.
-
-    We can't guarantee immediate response but our main developers see these messages and endeavour to respond as rapidly as possible. Join by using this button:
-
-    [Signal group](https://signal.group/#CjQKIAjLf5lS9OZIAI6lsJKWP1LmeJXkUW_fzZH1ryEw3oFEEhBH-4F7WnlyYjKerjfzD6B0){ .md-button .md-button--primary }
-
 ## Commercial Enquiries
 
 Email our Commercial Team to ask questions about support and pricing tiers, invoicing, contracts and other commercial matters.


### PR DESCRIPTION
We're not actively monitoring this group any more