### PR TITLE
Fix Swagger UI

### DIFF
--- a/docs/integrator/api-reference.md
+++ b/docs/integrator/api-reference.md
@@ -8,11 +8,11 @@ audience: integrators, implementers, technical-architects
 --8<-- "docs/_assets/_snippets/api-baseurl.md"
 
 <!-- Embeds the Swagger UI view of the API reference here -->
-<link type="text/css" rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@5/swagger-ui.css">
+<link type="text/css" rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@5.26.2/swagger-ui.css">
 
 <div id="swagger-ui"></div>
 
-<script src="https://unpkg.com/swagger-ui-dist@5/swagger-ui-bundle.js" charset="UTF-8"></script>
+<script src="https://unpkg.com/swagger-ui-dist@5.26.2/swagger-ui-bundle.js" charset="UTF-8"></script>
 
 <script>
     const ui = SwaggerUIBundle({


### PR DESCRIPTION
5.27.0 seems to have moved to a different bundling format that no longer sets SwaggerUIBundle on window.

Pin to 5.26.2 for now to fix.