### PR TITLE
Fix Swagger UI on page navigation

### DIFF
--- a/docs/_assets/_javascripts/swagger.js
+++ b/docs/_assets/_javascripts/swagger.js
@@ -1,6 +1,0 @@
-import swagger from "https://esm.sh/swagger-ui-dist@5";
-
-swagger.SwaggerUIBundle({
-    url: 'https://raw.githubusercontent.com/rcpch/digital-growth-charts-server/live/openapi.json',
-    dom_id: '#swagger-ui',
-});

--- a/docs/_assets/_javascripts/swagger.js
+++ b/docs/_assets/_javascripts/swagger.js
@@ -1,0 +1,6 @@
+import swagger from "https://esm.sh/swagger-ui-dist@5";
+
+swagger.SwaggerUIBundle({
+    url: 'https://raw.githubusercontent.com/rcpch/digital-growth-charts-server/live/openapi.json',
+    dom_id: '#swagger-ui',
+});

--- a/docs/_assets/swagger.html
+++ b/docs/_assets/swagger.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<head>
+    <link type="text/css" rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@5/swagger-ui.css">
+</head>
+<body>
+    <div id="swagger-ui"></div>
+    <script src="https://unpkg.com/swagger-ui-dist@5/swagger-ui-bundle.js" charset="UTF-8"></script>
+    <script>
+        SwaggerUIBundle({
+            url: 'https://raw.githubusercontent.com/rcpch/digital-growth-charts-server/live/openapi.json',
+            dom_id: '#swagger-ui',
+            onComplete: () => {
+                parent.postMessage({
+                    type: 'swagger-ui-loaded',
+                    height: document.body.scrollHeight
+                }, window.location.origin);
+            }
+        });
+    </script>
+</body>

--- a/docs/integrator/api-reference.md
+++ b/docs/integrator/api-reference.md
@@ -12,15 +12,24 @@ audience: integrators, implementers, technical-architects
 
 <div id="swagger-ui"></div>
 
-<script id="swagger-js" src="https://unpkg.com/swagger-ui-dist@5/swagger-ui-bundle.js" charset="UTF-8"></script>
+<script id="swagger-js"></script>
 
 <script>
-    // Workaround weird behaviour where this script executes before the ui bundle is loaded when
-    // mkdocs does a client side navigation between pages
-    setTimeout(() => {
+    // We enable instant navigation in mkdocs-material which does a client-side JS replacement of the page
+    // rather than loading it fresh. It simulates reloading script tags but it does so in parallel.
+    // (https://github.com/squidfunk/mkdocs-material/blob/9d958543d01ccedd0b6531f8129cfb76ef3d812a/src/templates/assets/javascripts/integrations/instant/index.ts#L222)
+    // This is not the same as how the browser would load the script tags initially, blocking on the first
+    // one before loading the second. The effect is that the Swagger UI loads fine if you load this page
+    // directly but crashes on a client side navigation.
+    // Work around this by listening to the `load` event on the swagger dist script.
+    const scriptTag = document.getElementById("swagger-js");
+
+    scriptTag.addEventListener("load", () => {
         window.SwaggerUIBundle({
             url: 'https://raw.githubusercontent.com/rcpch/digital-growth-charts-server/live/openapi.json',
             dom_id: '#swagger-ui',
         });
-    }, 0);
+    });
+
+    scriptTag.src = "https://unpkg.com/swagger-ui-dist@5/swagger-ui-bundle.js";
 </script>

--- a/docs/integrator/api-reference.md
+++ b/docs/integrator/api-reference.md
@@ -7,9 +7,14 @@ audience: integrators, implementers, technical-architects
 
 --8<-- "docs/_assets/_snippets/api-baseurl.md"
 
-<!-- Embeds the Swagger UI view of the API reference here -->
-<link type="text/css" rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@5/swagger-ui.css">
+<script>
+    window.addEventListener("message", (e) => {
+        console.log(e.data);
 
-<div id="swagger-ui"></div>
+        if(e.data && e.data.type === "swagger-ui-loaded") {
+            document.getElementById("swagger-ui").height = e.data.height + 100;
+        }
+    });
+</script>
 
-<script type="module" src="/_assets/_javascripts/swagger.js"></script>
+<iframe id="swagger-ui" src="/_assets/swagger.html" style="width: 100%"></iframe>

--- a/docs/integrator/api-reference.md
+++ b/docs/integrator/api-reference.md
@@ -9,8 +9,6 @@ audience: integrators, implementers, technical-architects
 
 <script>
     window.addEventListener("message", (e) => {
-        console.log(e.data);
-
         if(e.data && e.data.type === "swagger-ui-loaded") {
             document.getElementById("swagger-ui").height = e.data.height + 100;
         }

--- a/docs/integrator/api-reference.md
+++ b/docs/integrator/api-reference.md
@@ -12,15 +12,15 @@ audience: integrators, implementers, technical-architects
 
 <div id="swagger-ui"></div>
 
-<script src="https://unpkg.com/swagger-ui-dist@5/swagger-ui-bundle.js" charset="UTF-8"></script>
+<script id="swagger-js" src="https://unpkg.com/swagger-ui-dist@5/swagger-ui-bundle.js" charset="UTF-8"></script>
 
 <script>
-    document.onreadystatechange = () => {
-        if (document.readyState === "complete") {
-            window.SwaggerUIBundle({
-                url: 'https://raw.githubusercontent.com/rcpch/digital-growth-charts-server/live/openapi.json',
-                dom_id: '#swagger-ui',
-            });
-        }
-    };
+    // Workaround weird behaviour where this script executes before the ui bundle is loaded when
+    // mkdocs does a client side navigation between pages
+    setTimeout(() => {
+        window.SwaggerUIBundle({
+            url: 'https://raw.githubusercontent.com/rcpch/digital-growth-charts-server/live/openapi.json',
+            dom_id: '#swagger-ui',
+        });
+    }, 0);
 </script>

--- a/docs/integrator/api-reference.md
+++ b/docs/integrator/api-reference.md
@@ -8,11 +8,11 @@ audience: integrators, implementers, technical-architects
 --8<-- "docs/_assets/_snippets/api-baseurl.md"
 
 <!-- Embeds the Swagger UI view of the API reference here -->
-<link type="text/css" rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@5/swagger-ui.css">
+<link type="text/css" rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@5.26.2/swagger-ui.css">
 
 <div id="swagger-ui"></div>
 
-<script src="https://unpkg.com/swagger-ui-dist@5/swagger-ui-bundle.js" charset="UTF-8"></script>
+<script src="https://unpkg.com/swagger-ui-dist@5.26.2/swagger-ui-bundle.js" charset="UTF-8"></script>
 
 <script>
     const ui = SwaggerUIBundle({

--- a/docs/integrator/api-reference.md
+++ b/docs/integrator/api-reference.md
@@ -22,14 +22,21 @@ audience: integrators, implementers, technical-architects
     // one before loading the second. The effect is that the Swagger UI loads fine if you load this page
     // directly but crashes on a client side navigation.
     // Work around this by listening to the `load` event on the swagger dist script.
-    const scriptTag = document.getElementById("swagger-js");
 
-    scriptTag.addEventListener("load", () => {
-        window.SwaggerUIBundle({
-            url: 'https://raw.githubusercontent.com/rcpch/digital-growth-charts-server/live/openapi.json',
-            dom_id: '#swagger-ui',
+    // Defining scriptTag at the top level caused an error but only in the Azure build who even knows
+    // > Uncaught SyntaxError: Failed to execute 'replaceWith' on 'Element': Identifier 'scriptTag' has already been declared
+    // so wrap it in an IIFE since we can't use ES modules because the same mkdocs-material instant loading
+    // code strips out all attributes from script tags unless they have src
+    (() => {
+        const scriptTag = document.getElementById("swagger-js");
+
+        scriptTag.addEventListener("load", () => {
+            window.SwaggerUIBundle({
+                url: 'https://raw.githubusercontent.com/rcpch/digital-growth-charts-server/live/openapi.json',
+                dom_id: '#swagger-ui',
+            });
         });
-    });
 
-    scriptTag.src = "https://unpkg.com/swagger-ui-dist@5/swagger-ui-bundle.js";
+        scriptTag.src = "https://unpkg.com/swagger-ui-dist@5/swagger-ui-bundle.js";
+    })();
 </script>

--- a/docs/integrator/api-reference.md
+++ b/docs/integrator/api-reference.md
@@ -12,31 +12,4 @@ audience: integrators, implementers, technical-architects
 
 <div id="swagger-ui"></div>
 
-<script id="swagger-js"></script>
-
-<script>
-    // We enable instant navigation in mkdocs-material which does a client-side JS replacement of the page
-    // rather than loading it fresh. It simulates reloading script tags but it does so in parallel.
-    // (https://github.com/squidfunk/mkdocs-material/blob/9d958543d01ccedd0b6531f8129cfb76ef3d812a/src/templates/assets/javascripts/integrations/instant/index.ts#L222)
-    // This is not the same as how the browser would load the script tags initially, blocking on the first
-    // one before loading the second. The effect is that the Swagger UI loads fine if you load this page
-    // directly but crashes on a client side navigation.
-    // Work around this by listening to the `load` event on the swagger dist script.
-
-    // Defining scriptTag at the top level caused an error but only in the Azure build who even knows
-    // > Uncaught SyntaxError: Failed to execute 'replaceWith' on 'Element': Identifier 'scriptTag' has already been declared
-    // so wrap it in an IIFE since we can't use ES modules because the same mkdocs-material instant loading
-    // code strips out all attributes from script tags unless they have src
-    (() => {
-        const scriptTag = document.getElementById("swagger-js");
-
-        scriptTag.addEventListener("load", () => {
-            window.SwaggerUIBundle({
-                url: 'https://raw.githubusercontent.com/rcpch/digital-growth-charts-server/live/openapi.json',
-                dom_id: '#swagger-ui',
-            });
-        });
-
-        scriptTag.src = "https://unpkg.com/swagger-ui-dist@5/swagger-ui-bundle.js";
-    })();
-</script>
+<script type="module" src="/_assets/_javascripts/swagger.js"></script>

--- a/docs/integrator/api-reference.md
+++ b/docs/integrator/api-reference.md
@@ -8,15 +8,19 @@ audience: integrators, implementers, technical-architects
 --8<-- "docs/_assets/_snippets/api-baseurl.md"
 
 <!-- Embeds the Swagger UI view of the API reference here -->
-<link type="text/css" rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@5.26.2/swagger-ui.css">
+<link type="text/css" rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@5/swagger-ui.css">
 
 <div id="swagger-ui"></div>
 
-<script src="https://unpkg.com/swagger-ui-dist@5.26.2/swagger-ui-bundle.js" charset="UTF-8"></script>
+<script src="https://unpkg.com/swagger-ui-dist@5/swagger-ui-bundle.js" charset="UTF-8"></script>
 
 <script>
-    const ui = SwaggerUIBundle({
-    url: 'https://raw.githubusercontent.com/rcpch/digital-growth-charts-server/live/openapi.json',
-    dom_id: '#swagger-ui',
-    })
+    document.onreadystatechange = () => {
+        if (document.readyState === "complete") {
+            window.SwaggerUIBundle({
+                url: 'https://raw.githubusercontent.com/rcpch/digital-growth-charts-server/live/openapi.json',
+                dom_id: '#swagger-ui',
+            });
+        }
+    };
 </script>


### PR DESCRIPTION
The Swagger UI was only loading if you visited the page directly. If you navigated from another page it crashed:

```
Uncaught ReferenceError: SwaggerUIBundle is not defined
    at <anonymous>:2:16
    at index.ts:237:14
```

We  have instant navigation enabled in mkdocs-material which does a client-side JS replacement of the page rather than loading it fresh.

It simulates reloading script tags but it does so in parallel. [Code here](https://github.com/squidfunk/mkdocs-material/blob/9d958543d01ccedd0b6531f8129cfb76ef3d812a/src/templates/assets/javascripts/integrations/instant/index.ts#L222).

This is not the same as how the browser would load the script tags initially, blocking on the first one before loading the second. The effect is that the Swagger UI loads fine if you load the API reference page directly but crashes on a client side navigation.

Work around this by pushing out the code that loads the Swagger UI into a separate file and embedding it as an iframe