### PR TITLE
Remove duplicate PR environments

### DIFF
--- a/.github/workflows/ALL-BRANCHES-ALL-PRs-build-and-deploy-to-azure.yml
+++ b/.github/workflows/ALL-BRANCHES-ALL-PRs-build-and-deploy-to-azure.yml
@@ -2,14 +2,11 @@
 # and pushes it to Azure from where it is deployed
 # to the LIVE site https://growth.rcpch.ac.uk/
 #
-# Azure will also build a preview site for any PRs against LIVE or branches
+# Azure will also build a preview site for any PRs against live
 
 name: ALL-BRANCHES-ALL-PRs-build-and-deploy-to-azure.yml
 
 on:
-  push:
-    branches:
-      - "**"
   pull_request:
     types: [opened, synchronize, reopened, closed]
     branches:


### PR DESCRIPTION
Fixes #121

Avoid duplicate PR environments that are not torn down when the PR is closed by only triggering on GitHub actions pull_request events.

I think the duplication was introduced in #80.