### PR TITLE
Fix deploys

### DIFF
--- a/.github/workflows/ALL-BRANCHES-ALL-PRs-build-and-deploy-to-azure.yml
+++ b/.github/workflows/ALL-BRANCHES-ALL-PRs-build-and-deploy-to-azure.yml
@@ -7,6 +7,9 @@
 name: ALL-BRANCHES-ALL-PRs-build-and-deploy-to-azure.yml
 
 on:
+  push:
+    branches:
+      - live
   pull_request:
     types: [opened, synchronize, reopened, closed]
     branches:


### PR DESCRIPTION
Follow on from #132 - we still need the push to `live` trigger to do the deploy once the PR is closed