### PR TITLE
Update chart component library version to 7.5.0

### DIFF
--- a/docs/integrator/using-the-chart-component.md
+++ b/docs/integrator/using-the-chart-component.md
@@ -50,10 +50,10 @@ It is common in healthcare environments not to be able to use frameworks like Re
         <!-- RCPCH Growth Charts library -->
         <!-- You must use the integrity check to ensure you are using the expected code as this component   -->
         <!-- can render patient data. You can get the value from this file, adjusting the version as needed -->
-        <!-- https://cdn.jsdelivr.net/npm/@rcpch/digital-growth-charts-react-component-library@7.4.0/build/sri-hash.txt -->
+        <!-- https://cdn.jsdelivr.net/npm/@rcpch/digital-growth-charts-react-component-library@7.5.0/build/sri-hash.txt -->
         <script 
-            src="https://cdn.jsdelivr.net/npm/@rcpch/digital-growth-charts-react-component-library@7.4.0/build/rcpch-digital-growth-charts.umd.min.js" 
-            integrity="sha384-qi0VLSTriOa9dh7dMVRCLR5nZlgrNGrccCX6Xiw+4hvfeVTVXClhoiqViE2IFoPe" 
+            src="https://cdn.jsdelivr.net/npm/@rcpch/digital-growth-charts-react-component-library@7.5.0/build/rcpch-digital-growth-charts.umd.min.js" 
+            integrity="sha384-yu1MIbRclkM3UCyciRAULihnERx26NqFKjP/EuddYVumiom3Oy5p9KBGSUHABc8g" 
             crossorigin="anonymous"
             defer>
         </script>


### PR DESCRIPTION
https://forum.rcpch.tech/t/how-to-display-centile-on-tooltip/684/4

The eternal push pull between documentation and code!

We can't make it update automatically *and* include the correct SRI hash without modifying our docs build to poll for the latest version. Even if it did that it wouldn't update automatically without a release trigger between the library and the docs repo.

TBH I think it makes sense for us to direct people to a full blown iframe build that takes input as a `postMessage`. Then they can link to latest from an RCPCH controlled domain and not worry about an SRI hash unless they particularly want to.