### PR TITLE
Add tags to documentation pages to enhance search (#73)

### DIFF
--- a/docs/_assets/_stylesheets/extra.css
+++ b/docs/_assets/_stylesheets/extra.css
@@ -309,3 +309,32 @@ img {
     background-color: transparent !important;
   }
 }
+
+/* TAGS
+   Zensical renders frontmatter `tags` as pills at the foot of each page. On our
+   light scheme the default surface (`--md-default-fg-color--lightest`) is so
+   pale it reads as white, so give each tag a subtle RCPCH-tinted background and
+   a hairline border to make the bounding box obvious. We also inject a leading
+   `#` icon - reusing the theme's built-in `--md-tag-icon` glyph - on every tag
+   so they're instantly recognisable as tags (the icon otherwise only renders
+   for tags with an explicitly configured identifier). */
+.md-typeset .md-tag {
+  background-color: var(--rcpch-surface-tint-strong);
+  border: 1px solid var(--rcpch-border-color);
+}
+
+.md-typeset .md-tag::before {
+  content: "";
+  display: inline-block;
+  width: 1.2em;
+  height: 1.2em;
+  background-color: var(--md-primary-fg-color);
+  -webkit-mask-image: var(--md-tag-icon);
+  mask-image: var(--md-tag-icon);
+  -webkit-mask-position: center;
+  mask-position: center;
+  -webkit-mask-repeat: no-repeat;
+  mask-repeat: no-repeat;
+  -webkit-mask-size: contain;
+  mask-size: contain;
+}

--- a/docs/_utilities/page-template.md
+++ b/docs/_utilities/page-template.md
@@ -3,6 +3,11 @@
 # it can be a useful place to store document metadata
 title: This Title is Shown in the Left Sidebar Nav (can be different to Page Title)
 reviewers: Dr Example Writer, Dr Second Checker
+# tags add an extra layer of search discoverability - reuse the controlled
+# vocabulary documented in developer/writing-documentation.md
+tags:
+  - Example Tag
+  - Another Tag
 ---
 
 If the `<h1>` title is omitted, Zensical will use the `title:` attribute in the Nav and on the page

--- a/docs/about/about.md
+++ b/docs/about/about.md
@@ -2,6 +2,8 @@
 title: About the dGC
 reviewers: Dr Marcus Baw, Dr Anchit Chandran
 audience: all
+tags:
+  - Overview
 ---
 
 # The RCPCH Growth Charts Project

--- a/docs/about/acknowledgements.md
+++ b/docs/about/acknowledgements.md
@@ -2,6 +2,8 @@
 title: Acknowledgements
 reviewers: Dr Marcus Baw, Dr Anchit Chandran
 audience: all
+tags:
+  - Team
 ---
 
 # Acknowledgements

--- a/docs/about/awards-press-blogs.md
+++ b/docs/about/awards-press-blogs.md
@@ -2,6 +2,8 @@
 title: Awards, Press, Blogs
 reviewers: Dr Marcus Baw
 audience: all
+tags:
+  - Press and Awards
 ---
 
 # Awards, Press, Blogs, and other Mentions of the digital Growth Charts Project

--- a/docs/about/team.md
+++ b/docs/about/team.md
@@ -2,6 +2,8 @@
 title: dGC Team
 reviewers: Dr Marcus Baw, Prof Tim Cole, Dr Anchit Chandran
 audience: clinicians, health-staff
+tags:
+  - Team
 ---
 
 # Digital Growth Charts Team Members

--- a/docs/about/videos.md
+++ b/docs/about/videos.md
@@ -2,6 +2,8 @@
 title: Videos
 reviewers: Dr Marcus Baw
 audience: all
+tags:
+  - Videos
 ---
 
 # Videos

--- a/docs/about/whos-using-dgc.md
+++ b/docs/about/whos-using-dgc.md
@@ -2,6 +2,8 @@
 title: Who's Using the Digital Growth Charts
 reviewers: Dr Marcus Baw
 audience: all
+tags:
+  - Overview
 ---
 
 Since the inception of the RCPCH Digital Growth Charts we have worked with NHS and non-NHS organisations, software suppliers, and clinical teams to implement the Digital Growth Charts in their systems. Below is a list of some of the organisations and software suppliers that are currently using the Digital Growth Charts.

--- a/docs/clinician/chart-information-health-staff.md
+++ b/docs/clinician/chart-information-health-staff.md
@@ -2,6 +2,9 @@
 title: Information for Health Staff
 reviewers: Dr Marcus Baw, Dr Anchit Chandran
 audience: clinicians, health-staff
+tags:
+  - Growth Charts
+  - Centiles
 ---
 
 # Chart information for Health staff

--- a/docs/clinician/date-age-calculations.md
+++ b/docs/clinician/date-age-calculations.md
@@ -2,6 +2,9 @@
 title: Date and Age Calculations
 reviewers: Dr Marcus Baw, Dr Anchit Chandran
 audience: clinicians, health-staff, statisticians
+tags:
+  - Date and Age Calculations
+  - Centiles
 ---
 
 # Date and Age Calculations

--- a/docs/clinician/faqs-for-clinicians.md
+++ b/docs/clinician/faqs-for-clinicians.md
@@ -2,6 +2,8 @@
 title: FAQs for Clinicians
 reviewers: Dr Marcus Baw, Dr Anchit Chandran
 audience: clinicians, health-staff
+tags:
+  - FAQ
 ---
 
 # Frequently Asked Questions for Clinicians

--- a/docs/clinician/growth-chart-papers.md
+++ b/docs/clinician/growth-chart-papers.md
@@ -2,6 +2,9 @@
 title: Growth Chart Papers
 author: Dr Marcus Baw
 audience: clinicians, health-staff, researchers
+tags:
+  - Growth References
+  - Research
 ---
 
 # Growth chart papers

--- a/docs/clinician/growth-references.md
+++ b/docs/clinician/growth-references.md
@@ -2,6 +2,9 @@
 title: Reference Data
 reviewers: Dr Marcus Baw, Dr Simon Chapman, Dr Anchit Chandran
 audience: clinicians, health-staff
+tags:
+  - Growth References
+  - Centiles
 ---
 
 # Growth Chart References

--- a/docs/clinician/how-the-api-works.md
+++ b/docs/clinician/how-the-api-works.md
@@ -2,6 +2,9 @@
 title: How the API Works
 reviewers: Dr Marcus Baw, Dr Anchit Chandran
 audience: clinicians, health-staff, statisticians
+tags:
+  - API
+  - Centiles
 ---
 # How the API Works
 

--- a/docs/contact/contact.md
+++ b/docs/contact/contact.md
@@ -1,6 +1,8 @@
 ---
 reviewers: Dr Marcus Baw, Dr Anchit Chandran
 audience: all
+tags:
+  - Support
 ---
 
 # Contact

--- a/docs/developer/api-docker.md
+++ b/docs/developer/api-docker.md
@@ -2,6 +2,9 @@
 title: Docker development
 reviewers: Dr Marcus Baw, Dr Sean Cusack, Dr Anchit Chandran
 audience: developers
+tags:
+  - Docker
+  - API
 ---
 
 # Developing locally in a Docker container

--- a/docs/developer/api-python.md
+++ b/docs/developer/api-python.md
@@ -2,6 +2,9 @@
 title: Python development
 reviewers: Dr Marcus Baw, Dr Anchit Chandran
 audience: developers
+tags:
+  - Python
+  - API
 ---
 
 # Running locally with Python

--- a/docs/developer/api-testing.md
+++ b/docs/developer/api-testing.md
@@ -2,6 +2,9 @@
 title: Testing the API
 reviewers: Dr Marcus Baw, Dr Anchit Chandran
 audience: developers
+tags:
+  - Testing
+  - API
 ---
 
 # Testing the API

--- a/docs/developer/contributing.md
+++ b/docs/developer/contributing.md
@@ -2,6 +2,8 @@
 title: Contributing
 reviewers: Dr Marcus Baw, Dr Anchit Chandran
 audience: developers
+tags:
+  - Contributing
 ---
 
 ## Contributing

--- a/docs/developer/faqs-for-developers.md
+++ b/docs/developer/faqs-for-developers.md
@@ -2,6 +2,8 @@
 title: FAQs for Developers
 reviewers: Dr Marcus Baw, Dr Anchit Chandran
 audience: developers
+tags:
+  - FAQ
 ---
 
 # FAQs for Developers

--- a/docs/developer/rcpchgrowth-cli.md
+++ b/docs/developer/rcpchgrowth-cli.md
@@ -2,6 +2,9 @@
 title: RCPCHGrowth CLI
 reviewers: Dr Marcus Baw, Dr Simon Chapman
 audience: developers
+tags:
+  - Command Line
+  - Python
 ---
 
 # Developing the RCPCH CLI tools

--- a/docs/developer/rcpchgrowth.md
+++ b/docs/developer/rcpchgrowth.md
@@ -2,6 +2,8 @@
 title: RCPCHGrowth library
 reviewers: Dr Simon Chapman, Dr Anchit Chandran
 audience: developers
+tags:
+  - Python
 ---
 
 ## Overview

--- a/docs/developer/react-client.md
+++ b/docs/developer/react-client.md
@@ -2,6 +2,8 @@
 title: React Client
 reviewers: Dr Simon Chapman, Dr Marcus Baw
 audience: developers
+tags:
+  - React
 ---
 
 ## Developer documentation

--- a/docs/developer/react-component.md
+++ b/docs/developer/react-component.md
@@ -2,6 +2,9 @@
 title: React Chart Component
 reviewers: Dr Marcus Baw, Dr Simon Chapman, Dr Anchit Chandran
 audience: developers
+tags:
+  - React
+  - Growth Charts
 ---
 
 ## Getting started

--- a/docs/developer/start-here.md
+++ b/docs/developer/start-here.md
@@ -2,6 +2,9 @@
 title: Getting Started
 reviewers: Dr Marcus Baw, Dr Anchit Chandran
 audience: developers
+tags:
+  - Getting Started
+  - Contributing
 ---
 
 # Getting Started Developing the Digital Growth Charts project

--- a/docs/developer/versioning.md
+++ b/docs/developer/versioning.md
@@ -2,6 +2,8 @@
 title: Versioning
 reviewers: Dr Marcus Baw, Dr Anchit Chandran
 audience: developers
+tags:
+  - Versioning
 ---
 
 # Versioning the API Server's code

--- a/docs/developer/writing-documentation.md
+++ b/docs/developer/writing-documentation.md
@@ -2,6 +2,8 @@
 title: Writing Documentation
 reviewers: Dr Marcus Baw, Dr Anchit Chandran
 audience: developers
+tags:
+  - Contributing
 ---
 
 # Writing dGC Documentation
@@ -137,6 +139,30 @@ title: Some Page Title
 reviewers: Dr Marcus Baw, Dr Simon Chapman, Other Reviewer ...
 ---
 ```
+
+### Tags
+
+Pages can be categorised with **tags** in the YAML front matter. Zensical renders these tags at the foot of the page and indexes them into the site search, giving readers an extra layer of discoverability on top of the navigation tree and full-text search.
+
+```yaml hl_lines="4 5 6 7"
+---
+title: Some Page Title
+reviewers: Dr Marcus Baw
+tags:
+  - API
+  - Integration
+---
+```
+
+To keep tags useful, please reuse the **controlled vocabulary** already in use across the docs rather than inventing new, one-off tags. The current vocabulary is:
+
+`API`, `API Reference`, `Integration`, `SNOMED CT`, `Growth Charts`, `Growth References`, `Centiles`, `Date and Age Calculations`, `React`, `Python`, `Docker`, `Flutter`, `Command Line`, `Testing`, `Versioning`, `Contributing`, `Getting Started`, `FAQ`, `Clinical Safety`, `Hazards`, `Medical Device Regulation`, `DTAC`, `Data Protection`, `Privacy`, `Security`, `Licensing`, `Legal`, `Pricing`, `Research`, `Support`, `Team`, `Press and Awards`, `Videos`, `Overview`, `Deprecated`.
+
+Aim for two to four tags per page that describe its **subject matter**. If a page genuinely needs a new tag, add it here too so the vocabulary stays consistent.
+
+!!! note "Tag index page"
+
+    Zensical does not yet support a generated tags *index/listing* page (a single page that lists every tag and its pages). When [that feature ships](https://github.com/zensical/backlog/issues/38) we can add a `tags.md` listing page.
 
 ## Markdown Linting and Spellchecking
 

--- a/docs/integrator/api-reference.md
+++ b/docs/integrator/api-reference.md
@@ -2,6 +2,10 @@
 title: API Reference
 reviewers: Dr Marcus Baw, Dr Simon Chapman, Dr Anchit Chandran
 audience: integrators, implementers, technical-architects
+tags:
+  - API
+  - API Reference
+  - Integration
 ---
 # API Reference
 

--- a/docs/integrator/chart-component-storybook.md
+++ b/docs/integrator/chart-component-storybook.md
@@ -2,6 +2,10 @@
 title: Chart Component Storybook
 reviewers: Dr Marcus Baw, Dr Simon Chapman
 audience: integrators, implementers, technical-architects, developers
+tags:
+  - React
+  - Growth Charts
+  - Integration
 ---
 
 # Chart Component Storybook

--- a/docs/integrator/client-specification.md
+++ b/docs/integrator/client-specification.md
@@ -2,6 +2,9 @@
 title: Client Specification
 reviewers: Dr Marcus Baw, Dr Simon Chapman, Dr Anchit Chandran
 audience: integrators, implementers, technical-architects
+tags:
+  - Integration
+  - API
 ---
 
 In this document, we have collated the exact specification mandated by the Digital Growth Charts Project Board for Digital Growth Charts. Much of the specification is inherited from the preceding paper growth charts, so clinicians have immediate familiarity using the digital version.

--- a/docs/integrator/faqs-for-integrators.md
+++ b/docs/integrator/faqs-for-integrators.md
@@ -2,6 +2,9 @@
 title: FAQs for Integrators
 reviewers: Dr Marcus Baw, Dr Anchit Chandran
 audience: integrators, implementers, technical-architects
+tags:
+  - FAQ
+  - Integration
 ---
 
 # FAQs for Integrators

--- a/docs/integrator/getting-started.md
+++ b/docs/integrator/getting-started.md
@@ -2,6 +2,10 @@
 title: Getting Started
 reviewers: Dr Marcus Baw, Dr Anchit Chandran, Michael Barton
 audience: integrators, implementers, technical-architects
+tags:
+  - Getting Started
+  - Integration
+  - API
 ---
 # Getting Started with Digital Growth Charts
 

--- a/docs/integrator/making-api-calls.md
+++ b/docs/integrator/making-api-calls.md
@@ -2,6 +2,9 @@
 title: Making API Calls
 reviewers: Dr Marcus Baw, Dr Simon Chapman
 audience: integrators, implementers, technical-architects
+tags:
+  - API
+  - Integration
 ---
 
 # Making calls to the Digital Growth Charts API
@@ -103,7 +106,7 @@ You should get a nicely formatted JSON response object:
 
 The response object from the API contains dates without times in the format `YYYY-MM-DD`. This is the format that the digital growth charts react component library expects. If the output of the API is passed directly to the charts they will render the measurements automatically. RCPCH recommend that the response is persisted, so that an API call is only required for each new measurement.
 
-If in the process of serializing or deserializing the response, the date format is changed, RCPCH advise ensuring that the dates do not change format. In case this happens, the charting component is optimized to process common date types, but will log this as a warning in the console. Any unparseable dates will log as errors.
+If in the process of serializing or deserializing the response, the date format is changed, RCPCH advise ensuring that the dates do not change format. In case this happens, the charting component is optimized to process common date types, but will log this as a warning in the console. Any un-parseable dates will log as errors.
 
 ## Optional parameters and advanced features
 

--- a/docs/integrator/snomed-codes.md
+++ b/docs/integrator/snomed-codes.md
@@ -2,6 +2,9 @@
 title: SNOMED CT Codes for Storing Results
 reviewers: Dr Marcus Baw
 audience: integrators, implementers, technical-architects
+tags:
+  - SNOMED CT
+  - Integration
 ---
 
 # SNOMED CT codes for storing growth results

--- a/docs/integrator/support.md
+++ b/docs/integrator/support.md
@@ -2,6 +2,9 @@
 title: Support
 reviewers: Dr Marcus Baw, Dr Anchit Chandran
 audience: integrators, implementers, technical-architects
+tags:
+  - Support
+  - Integration
 ---
 
 # Support

--- a/docs/integrator/turner-down-syndrome.md
+++ b/docs/integrator/turner-down-syndrome.md
@@ -2,6 +2,9 @@
 title: Turner & Down Syndrome Implementation Guidance
 reviewers: Dr Marcus Baw
 audience: integrators, implementers, clinicians
+tags:
+  - Growth References
+  - Integration
 ---
 
 # Turner Syndrome and Down Syndrome: Implementation Guidance

--- a/docs/integrator/using-the-chart-component.md
+++ b/docs/integrator/using-the-chart-component.md
@@ -2,6 +2,10 @@
 title: Using the Chart Component
 reviewers: Dr Simon Chapman, Dr Marcus Baw
 audience: integrators, implementers, technical-architects
+tags:
+  - React
+  - Growth Charts
+  - Integration
 ---
 
 ## Installing the RCPCH Digital Growth Charts React Component

--- a/docs/legal/data-protection.md
+++ b/docs/legal/data-protection.md
@@ -2,6 +2,9 @@
 title: Data Protection
 reviewers: Dr Marcus Baw, Dr Anchit Chandran
 audience: clinicians, caldicott-guardians, data-protection-officers, developers
+tags:
+  - Data Protection
+  - Legal
 ---
 
 # Data Protection Considerations

--- a/docs/legal/disclaimer.md
+++ b/docs/legal/disclaimer.md
@@ -2,6 +2,8 @@
 title: DISCLAIMER
 reviewers: Dr Marcus Baw, Dr Anchit Chandran
 audience: implementers, developers
+tags:
+  - Legal
 ---
 
 # DISCLAIMER

--- a/docs/legal/licensing-copyright.md
+++ b/docs/legal/licensing-copyright.md
@@ -2,6 +2,9 @@
 title: Licensing and Copyright
 reviewers: Dr Marcus Baw, Dr Anchit Chandran
 audience: implementers, developers, clinicians
+tags:
+  - Licensing
+  - Legal
 ---
 
 # Licensing and Copyright

--- a/docs/legal/privacy-notice.md
+++ b/docs/legal/privacy-notice.md
@@ -2,6 +2,10 @@
 title: Privacy Notice
 reviewers: Dr Marcus Baw, Dr Anchit Chandran, Adele Picken
 audience: caldicott-guardians, implementers, developers
+tags:
+  - Privacy
+  - Data Protection
+  - Legal
 ---
 
 # Privacy Notice

--- a/docs/parents/chart-information-families.md
+++ b/docs/parents/chart-information-families.md
@@ -2,6 +2,8 @@
 title: Information for Parents
 reviewers: Dr Marcus Baw, Dr Anchit Chandran
 audience: parents, carers, families
+tags:
+  - Growth Charts
 ---
 
 # Information for Parents

--- a/docs/parents/faqs-parents.md
+++ b/docs/parents/faqs-parents.md
@@ -2,6 +2,8 @@
 title: Frequently Asked Questions
 reviewers: Dr Anchit Chandran, Dr Marcus Baw
 audience: parents
+tags:
+  - FAQ
 ---
 
 ## I didn’t breastfeed, or I stopped early – are these charts still right for my baby?

--- a/docs/products/api-server.md
+++ b/docs/products/api-server.md
@@ -2,6 +2,9 @@
 title: dGC API Server
 reviewers: Dr Marcus Baw
 audience: developers, integrators, implementers
+tags:
+  - API
+  - Docker
 ---
 
 {% set repository_name="rcpch/digital-growth-charts-server" -%}

--- a/docs/products/command-line-client(deprecated).md
+++ b/docs/products/command-line-client(deprecated).md
@@ -2,6 +2,9 @@
 title: RCPCHGrowth CLI Tool
 reviewers: Dr Marcus Baw, Dr Simon Chapman, Dr Anchit Chandran
 audience: developers, researchers
+tags:
+  - Command Line
+  - Deprecated
 ---
 
 # RCPCHGrowth CLI Tool ( :warning: deprecated)

--- a/docs/products/flask(deprecated).md
+++ b/docs/products/flask(deprecated).md
@@ -2,6 +2,9 @@
 title: Flask/Python Client (deprecated)
 reviewers: Dr Marcus Baw, Dr Anchit Chandran
 audience: developers, implementers, integrators
+tags:
+  - Python
+  - Deprecated
 ---
 
 # Flask/Python ( :warning: deprecated)

--- a/docs/products/flutter-app.md
+++ b/docs/products/flutter-app.md
@@ -2,6 +2,8 @@
 title: dGC App
 reviewers: Dr Simon Chapman
 audience: developers, integrators
+tags:
+  - Flutter
 ---
 
 # RCPCH Digital Growth Charts App

--- a/docs/products/get-digital-growth-charts.md
+++ b/docs/products/get-digital-growth-charts.md
@@ -2,6 +2,9 @@
 title: Get Digital Growth Charts
 reviewers: Dr Marcus Baw, Dr Anchit Chandran
 audience: implementers, clinicians
+tags:
+  - Getting Started
+  - Pricing
 ---
 
 ## Are paper growth charts holding up digital transformation?

--- a/docs/products/google-sheets-plugin.md
+++ b/docs/products/google-sheets-plugin.md
@@ -2,6 +2,8 @@
 title: Google Sheets Plugin
 reviewers: Dr Marcus Baw, Dr Anchit Chandran
 audience: developers, implementers, integrators, researchers, academics
+tags:
+  - Research
 ---
 
 [:octicons-mark-github-16: GitHub Repository](https://github.com/rcpch/digital-growth-charts-google-sheets-plugin)

--- a/docs/products/pricing.md
+++ b/docs/products/pricing.md
@@ -2,6 +2,8 @@
 title: Pricing
 reviewers: Dr Marcus Baw, Dr Simon Chapman, Dr Anchit Chandran
 audience: implementers, integrators, developers
+tags:
+  - Pricing
 ---
 
 # Pricing and Commercial Information

--- a/docs/products/products-overview.md
+++ b/docs/products/products-overview.md
@@ -2,6 +2,8 @@
 title: Products Overview
 reviewers: Dr Marcus Baw, Dr Anchit Chandran
 audience: implementers, clinicians
+tags:
+  - Overview
 ---
 
 # Products Overview

--- a/docs/products/python-library.md
+++ b/docs/products/python-library.md
@@ -2,6 +2,9 @@
 title: RCPCHGrowth Package
 reviewers: Dr Marcus Baw, Dr Simon Chapman, Dr Anchit Chandran
 audience: developers, researchers, academics
+tags:
+  - Python
+  - Research
 ---
 
 {% set repository_name="rcpch/rcpchgrowth-python" -%}

--- a/docs/products/react-client.md
+++ b/docs/products/react-client.md
@@ -2,6 +2,8 @@
 title: React Demo Client
 reviewers: Dr Marcus Baw, Dr Anchit Chandran
 audience: developers, integrators, implementers
+tags:
+  - React
 ---
 
 # React Demo Client

--- a/docs/products/react-component.md
+++ b/docs/products/react-component.md
@@ -2,6 +2,9 @@
 title: React Chart Component
 reviewers: Dr Marcus Baw, Dr Simon Chapman, Dr Anchit Chandran
 audience: developers, integrators, implementers
+tags:
+  - React
+  - Growth Charts
 ---
 
 {% set repository_name="rcpch/digital-growth-charts-react-component-library" -%}

--- a/docs/researchers/introduction.md
+++ b/docs/researchers/introduction.md
@@ -2,6 +2,9 @@
 title: RCPCHGrowth and Research
 reviewers: Dr Simon Chapman
 audience: researchers
+tags:
+  - Research
+  - Python
 ---
 
 # How to Use RCPCHgrowth in Research

--- a/docs/safety/csmf/clinical-risk-mgmt-plan.md
+++ b/docs/safety/csmf/clinical-risk-mgmt-plan.md
@@ -2,6 +2,8 @@
 title: Clinical Risk Management Plan
 reviewers: Dr Marcus Baw
 audience: clinical-safety
+tags:
+  - Clinical Safety
 ---
 
 # Clinical Risk Management Plan

--- a/docs/safety/csmf/clinical-risk-mgmt-system.md
+++ b/docs/safety/csmf/clinical-risk-mgmt-system.md
@@ -2,6 +2,8 @@
 title: Clinical Risk Management System
 reviewers: Dr Marcus Baw
 audience: clinical-safety
+tags:
+  - Clinical Safety
 ---
 
 # Clinical Risk Management System

--- a/docs/safety/csmf/clinical-safety-case-report.md
+++ b/docs/safety/csmf/clinical-safety-case-report.md
@@ -2,6 +2,8 @@
 title: Clinical Safety Case Report
 reviewers: Dr Marcus Baw
 audience: clinical-safety, clinicians, implementers
+tags:
+  - Clinical Safety
 ---
 
 # Clinical Safety Case Report for the RCPCH Digital Growth Charts Platform

--- a/docs/safety/csmf/hazard-log.md
+++ b/docs/safety/csmf/hazard-log.md
@@ -2,6 +2,9 @@
 title: Hazard Log
 reviewers: Dr Marcus Baw
 audience: clinical-safety
+tags:
+  - Clinical Safety
+  - Hazards
 ---
 
 # Digital Growth Charts Hazard Log

--- a/docs/safety/csmf/license.md
+++ b/docs/safety/csmf/license.md
@@ -2,11 +2,14 @@
 title: CSMS License
 reviewers: Dr Marcus Baw
 audience: clinical-safety, implementers
+tags:
+  - Clinical Safety
+  - Licensing
 ---
 
 # License file for the RCPCH dGC Clinical Safety Management File
 
-This clinical safety management file is unusual in that it is in a public repository. Having completely open clinical safety documention is a good way to increase transparency and to demonstrate genuine attention to clinical safety issues.
+This clinical safety management file is unusual in that it is in a public repository. Having completely open clinical safety documentation is a good way to increase transparency and to demonstrate genuine attention to clinical safety issues.
 
 We are happy for it to be reused by others implementing open source projects. If you do reuse any part of this work, you **must** attribute the Royal College of Paediatrics and Child Health, and follow the other terms of this license. If you are a commercial organisation wishing to use this documentation then we may consider dual-licensing to allow for this. Please contact us.
 

--- a/docs/safety/csmf/third-party-tools-safety-assmt.md
+++ b/docs/safety/csmf/third-party-tools-safety-assmt.md
@@ -2,6 +2,8 @@
 title: Third Party Tools Safety
 reviewers: Dr Marcus Baw
 audience: clinical-safety, developers
+tags:
+  - Clinical Safety
 ---
 
 # Third Party Tools Safety

--- a/docs/safety/download.md
+++ b/docs/safety/download.md
@@ -3,6 +3,8 @@ title: Downloads
 author: Dr Marcus Baw
 audience: clinical-safety, clinicians, implementers
 reviewers: Dr Marcus Baw
+tags:
+  - Clinical Safety
 ---
 
 This page provides downloadable versions of the RCPCH Digital Growth Charts documentation and supporting materials.

--- a/docs/safety/dtac.md
+++ b/docs/safety/dtac.md
@@ -2,6 +2,9 @@
 title: DTAC
 reviewers: Dr Marcus Baw, Magda Umerska, Adele Picken
 audience: clinical-safety, implementers
+tags:
+  - DTAC
+  - Clinical Safety
 ---
 
 # Digital Technology Assessment Criteria (DTAC)

--- a/docs/safety/medical-device-reg/doc-api.md
+++ b/docs/safety/medical-device-reg/doc-api.md
@@ -2,6 +2,8 @@
 title: Declaration of Conformity
 reviewers: Dr Marcus Baw
 audience: clinical-safety, implementers
+tags:
+  - Medical Device Regulation
 ---
 
 # Declaration of Conformity (API Server)

--- a/docs/safety/medical-device-reg/essential-req.md
+++ b/docs/safety/medical-device-reg/essential-req.md
@@ -2,6 +2,8 @@
 title: MHRA Essential Requirements
 reviewers: Dr Marcus Baw, Dr Simon Chapman
 audience: clinical-safety, implementers
+tags:
+  - Medical Device Regulation
 ---
 
 !!! info "MHRA Medical device essential requirements - general"

--- a/docs/safety/medical-device-reg/mdr-technical-docs.md
+++ b/docs/safety/medical-device-reg/mdr-technical-docs.md
@@ -2,6 +2,8 @@
 title: Technical Documentation
 reviewers: Dr Marcus Baw
 audience: clinical-safety, implementers
+tags:
+  - Medical Device Regulation
 ---
 
 # Technical Documentation for EU Medical Device Regulation

--- a/docs/safety/medical-device-reg/mhra.md
+++ b/docs/safety/medical-device-reg/mhra.md
@@ -2,6 +2,8 @@
 title: UK Medical Device Registration
 reviewers: Dr Marcus Baw
 audience: clinical-safety, implementers
+tags:
+  - Medical Device Regulation
 ---
 
 The Digital Growth Charts API server and associated user interface libraries (together termed the RCPCH dGC Platform) are a Medical Device as determined under the [Medical Devices Regulations 2002](https://www.legislation.gov.uk/uksi/2002/618/regulation/2/made), *Regulation 2 (1) "medical device" (a) (i)* in that it "is intended by the manufacturer to be used for human beings for the purpose of diagnosis, prevention, monitoring, treatment or alleviation of disease".

--- a/docs/safety/overview.md
+++ b/docs/safety/overview.md
@@ -2,6 +2,9 @@
 title: "Overview"
 reviewers: Dr Marcus Baw
 audience: clinical-safety, clinicians, implementers
+tags:
+  - Clinical Safety
+  - Overview
 ---
 
 # Clinical Safety of the dGC Project

--- a/docs/technical/data-security-protection-toolkit.md
+++ b/docs/technical/data-security-protection-toolkit.md
@@ -2,6 +2,9 @@
 title: Data Security and Protection Toolkit
 reviewers: Dr Marcus Baw, Dr Anchit Chandran
 audience: data-protection-officers, clinical-safety, implementers
+tags:
+  - Data Protection
+  - Security
 ---
 
 # Data Security and Protection Toolkit

--- a/docs/technical/security.md
+++ b/docs/technical/security.md
@@ -2,6 +2,8 @@
 title: Security
 reviewers: Dr Marcus Baw, Dr Anchit Chandran
 audience: technical-architects, implementers, developers
+tags:
+  - Security
 ---
 
 # Security

--- a/docs/technical/status.md
+++ b/docs/technical/status.md
@@ -2,6 +2,8 @@
 title: Service Status
 reviewers: Dr Marcus Baw, Dr Anchit Chandran
 audience: all
+tags:
+  - Support
 ---
 
 # dGC Service Status

--- a/spec/roadmap.md
+++ b/spec/roadmap.md
@@ -2,9 +2,13 @@
 
 The bulk of the 2026 documentation review is complete and is captured in [PR #161](https://github.com/rcpch/digital-growth-charts-documentation/pull/161). What remains is grouped below: work that is blocked on an upstream dependency, and improvements deferred to a future cycle.
 
+## Completed
+
+- [x] Apply page-level tags via frontmatter across the docs for an extra layer of search discoverability (the first half of <https://github.com/rcpch/digital-growth-charts-documentation/issues/73>). Zensical now supports frontmatter `tags`, which render at the foot of each page and are indexed into search (<https://zensical.org/docs/setup/tags/>). The tag vocabulary and convention are documented in `docs/developer/writing-documentation.md`.
+
 ## Blocked Upstream
 
-- [ ] Add Tags to the documentation site, applied via page frontmatter and indexed into a tags page, for an extra layer of discoverability (<https://github.com/rcpch/digital-growth-charts-documentation/issues/73>). Blocked until Zensical supports the `material/tags` plugin (tracking: <https://github.com/zensical/backlog/issues/38>).
+- [ ] Add a tags index/listing page that aggregates all tags into a browsable `tags.md` (the second half of <https://github.com/rcpch/digital-growth-charts-documentation/issues/73>). Page-level tags themselves now ship via frontmatter (see the Completed section), but tag *listings* are still not supported by Zensical (tracking: <https://github.com/zensical/backlog/issues/38>). Add the index page once Zensical supports it.
 
 ## Future Improvements
 


### PR DESCRIPTION
Zensical now supports frontmatter `tags`, which render at the foot of each page and are indexed into search. This adds a controlled tag vocabulary to page frontmatter across the docs for an extra layer of discoverability.

- Tag ~70 pages with a consistent controlled vocabulary
- Style tags in extra.css: RCPCH-tinted background, hairline border and a leading `#` icon (reusing the theme's built-in tag glyph) so they read clearly as tags
- Document the tags convention and vocabulary in writing-documentation.md
- Add a tags scaffold to the page template
- Update roadmap.md: frontmatter tags done; tag index page still pending upstream Zensical support