### PR TITLE
Phase 1: complete the hazard log and harden medical-device docs

### DIFF
--- a/docs/safety/csmf/clinical-safety-case-report.md
+++ b/docs/safety/csmf/clinical-safety-case-report.md
@@ -82,7 +82,7 @@ More detail of the individual risks and descriptions of the pre- and post-mitiga
 
 If the API does not respond, then centile measurements and graphical growth charts will be unavailable. Possible causes include failure of internet connectivity (at the implementing site, at the supplier/integrator, or at the Microsoft Azure UK data centre), failure of internal networking within the Azure cloud platform, failure of proxying through the Azure API Management platform, or failure of the API server WebApp platform or application code.
 
-The API server runs on high-availability Microsoft Azure public cloud infrastructure and is hardened to above industry standard.
+The API server runs on high-availability Microsoft Azure public cloud infrastructure and is hardened to above industry standard. The technical causes within the RCPCH's control are mitigated by an automated test suite and peer review of the server code before deployment, version-locked dependencies, and the service-level agreements covering the Azure App Service and API Management platforms; connectivity failures at the implementing site or integrator are outside RCPCH control and are addressed within the implementer's own DCB0160 assessment. A full mapping of each possible cause to its mitigation is recorded in the hazard issue.
 
 The Project Board felt the unavailability of the API would be unlikely to cause any form of harm to a patient because there are immediately available fallback methods such as manual calculation on printed paper charts.
 

--- a/docs/safety/csmf/clinical-safety-case-report.md
+++ b/docs/safety/csmf/clinical-safety-case-report.md
@@ -80,6 +80,8 @@ More detail of the individual risks and descriptions of the pre- and post-mitiga
 
 #### Description of initial Risk and mitigation steps
 
+If the API does not respond, then centile measurements and graphical growth charts will be unavailable. Possible causes include failure of internet connectivity (at the implementing site, at the supplier/integrator, or at the Microsoft Azure UK data centre), failure of internal networking within the Azure cloud platform, failure of proxying through the Azure API Management platform, or failure of the API server WebApp platform or application code.
+
 The API server runs on high-availability Microsoft Azure public cloud infrastructure and is hardened to above industry standard.
 
 The Project Board felt the unavailability of the API would be unlikely to cause any form of harm to a patient because there are immediately available fallback methods such as manual calculation on printed paper charts.
@@ -90,40 +92,90 @@ Minor
 
 #### Likelihood
 
-Medium
+Low
 
 #### Residual Risk Level
 
+1 - Acceptable
+
 #### Outcome
 
-                                    |                      | Level 1 - Acceptable  |
-
-| | RCPCH endeavours to ensure that implementer organisations have appropriate support in order to reduce the risk of errors in passing data to the API | Level 1 - Transferred |
-| Misuse of the API code by external organisations
+The residual risk is rated **Level 1 - Acceptable**. No further risk control measures are required. Implementers are advised to retain access to printed reference charts as a fallback.
 
 ---
 
 ### Hazard: Wrong data is _entered into_ the Digital Growth Chart API
 
+<https://github.com/rcpch/digital-growth-charts-documentation/issues/48>
+
 #### Description of initial Risk and mitigation steps
 
-In both the above scenarios, our Project Board of clinical paediatrics and growth experts agreed that the absolute risk of directly attributable harm to a child is rather low, because of the multiple clinical practice safeguards that exist whether the growth chart is paper, PDF or digital.
+Incorrect data could be sent to the API, which would cause the API to return incorrect results, with the potential for an aberrant clinical decision to be made on the basis of those results. The possible causes all originate _outside_ of the API — for example a client user-interface error that allows the wrong data to be entered, a poor UI design that makes common errors difficult to spot, or an internal client data-transfer error that sends incorrect data to the API _despite_ correct data being entered in the UI.
+
+The RCPCH does **not** control the client software which uses the API. All dGC client software is **itself** subject to NHS Clinical Safety standards (DCB0160), and this risk must also be considered within the implementer's **own** Hazard Log and Clinical Safety Case.
+
+As with most of the Growth Chart Hazards, the potential harm is that a child either does not receive intervention when it _should_, or receives inappropriate intervention when it _should not_. In both these scenarios, our Project Board of clinical paediatrics and growth experts agreed that the absolute risk of directly attributable harm to a child is rather low, because of the multiple clinical practice safeguards that exist whether the growth chart is paper, PDF or digital. Because growth is slow, decisions about monitoring and intervention are usually based on multiple measurements over a period of time, with constant 'clinical correlation' between the chart findings and the presentation and appearance of the patient. A single erroneous reading is therefore unlikely to result in an incorrect clinical decision; indeed, a single outlying point that is at odds with the preceding trend itself alerts clinical suspicion, so the chart plot is part of the long-established clinical error-rejection mechanism that predates digital charting and APIs.
 
 #### Severity
 
+Minor
+
 #### Likelihood
+
+Low
 
 #### Residual Risk Level
 
+1 - Acceptable
+
 #### Outcome
 
-RCPCH endeavours to ensure that implementer organisations have appropriate support in order to reduce the risk of errors in passing data to the API, however much of the implementation risk must necessarily be passed on to the DCB0160 clinical safety assessment.
+The residual risk is rated **Level 1 - Acceptable**. RCPCH endeavours to ensure that implementer organisations have appropriate support in order to reduce the risk of errors in passing data to the API; however, much of the implementation risk must necessarily be transferred to the implementer's DCB0160 clinical safety assessment.
+
+---
+
+### Hazard: Wrong units of measurement are used for the data sent to the API
+
+<https://github.com/rcpch/digital-growth-charts-documentation/issues/88>
+
+#### Description of initial Risk and mitigation steps
+
+If the API receives data in the wrong units, the result of the calculation could be wrong or misleading. For example, a weight measured in grams but sent to the API as kilograms would produce a very high weight centile, and a height measured in metres but sent as centimetres would produce a very low height centile. This would have to occur as part of a mis-implementation by the supplier or implementing organisation, or a significant user error, and the erroneous value would not necessarily be distinguishable from a correct one in the user interface. In a worst case, this could lead to unnecessary monitoring or treatment prompted by concern about a markedly outlying single measurement.
+
+The following mitigations are in place:
+
+- **Technical** — the API rejects significantly outlying data in the request. The validation ranges are defined in the `rcpchgrowth` Python library ([validation_constants.py](https://github.com/rcpch/rcpchgrowth-python/blob/live/rcpchgrowth/constants/validation_constants.py)); for example, a height passed as `1.15` (metres) is rejected with the error "Height/length must be passed in cm, not metres".
+- **Implementation guidance** — the RCPCH [demonstration user interface](https://growth.rcpch.ac.uk/) validates outlying values and raises errors for obviously incorrect input. Implementers are encouraged to use the open-source demo as 'live-code documentation' and as a framework to start from.
+- **Interface** — an extremely outlying result is markedly divergent from the existing growth trajectory on the chart, which should raise concern. The UI is clearly labelled with the units required.
+- **Training** — clinicians are trained not to take action on the basis of a single outlying growth result, and on the correct units to use (cm for length/height/OFC, kg for weight).
+
+With thanks to John Meredith of Digital Health and Care Wales, whose request for clarification prompted the creation of this Hazard.
+
+#### Severity
+
+Minor
+
+#### Likelihood
+
+Low
+
+#### Residual Risk Level
+
+1 - Acceptable
+
+#### Outcome
+
+The residual risk is rated **Level 1 - Acceptable**. The combination of technical error-rejection, implementation guidance, clear interface labelling and clinical training reduces the post-mitigation risk to an acceptable level. Much of the residual implementation risk is transferred to the implementer's DCB0160 clinical safety assessment.
 
 ---
 
 ### Hazard: Incorrect centile data is _returned by_ the API
 
+<https://github.com/rcpch/digital-growth-charts-documentation/issues/49>
+
 #### Description of initial Risk and mitigation steps
+
+The API could return incorrect centile data, presenting the user with an incorrect set of centiles and creating the potential for an inappropriate clinical decision to be made if the incorrect data were not recognised as such.
 
 Prior to deployment of the Digital Growth Charts, significant 'static' software testing was performed, to ensure that the complex statistical calculations returned by the API had been confirmed to have a very high degree of conformity to previous statistical Centile calculation engines, across a synthetic 'test harness' of approximately 4000 children's data. It is worth noting that the agreement between the systems was to 4 decimal places, the small variation between these is accounted for by the fact that statistics uses complex modelling of curves and interpolation, so it is impossible to get perfect alignment between two systems written in different languages (in this case, R and Python).
 
@@ -141,21 +193,45 @@ Very Low
 
 #### Residual Risk Level
 
+2 - Acceptable
+
 #### Outcome
+
+The residual risk is rated **Level 2 - Acceptable**. The extensive static and end-to-end testing supervised by Prof Tim Cole reduces the likelihood of an incorrect centile being returned to Very Low, and no further risk control measures are required.
 
 ---
 
 ### Hazard: Misuse of the API code by external organisations
 
+<https://github.com/rcpch/digital-growth-charts-documentation/issues/50>
+
 #### Description of initial Risk and mitigation steps
+
+The dGC code is open source, which means an external organisation could decide to self-host the API and make an error in its implementation or deployment, leading to erroneous results. The motivation for self-hosting might, for example, be to avoid the API subscription fees. Implementing digital growth charts is technically difficult, and even a technically competent organisation could make elementary errors in clinical interpretation, or accidentally skew the statistical model that generates the Growth Chart response data, returning erroneous data that could mislead clinicians in their management of a patient and lead to suboptimal care.
+
+Based on discussions across the Hazard Log, the Project Board did not think it plausible that the death of a patient could occur from this kind of error; in their extensive paediatric careers they had not experienced harm of a high severity occurring solely from aberrant growth chart data.
+
+The following mitigations are in place:
+
+- The RCPCH offers a commercial support tier that provides a warranted on-premise deployment for organisations that wish to run a safe, dedicated API server on their own infrastructure.
+- The dGC documentation warns strongly, in a number of places, against self-hosting of the API, and explains the reasoning in detail.
+- Beyond this, the residual risk occurs completely outside the control of the RCPCH. Closing the source of the application would remove the ability for others to host it, but would also have very serious side-effects, curtailing the open transparency, auditability and safety profile of the project. Closing the source code is therefore not considered an appropriate mitigation.
 
 #### Severity
 
+Minor
+
 #### Likelihood
+
+Medium
 
 #### Residual Risk Level
 
+2 - Acceptable
+
 #### Outcome
+
+The residual risk is rated **Level 2 - Acceptable**. The risk arises from third-party use that is expressly outwith the intended commercial use of the platform (see [Intended Use](#intended-use)); it is mitigated by the availability of a warranted on-premise deployment tier and by strong documentation warnings against self-hosting.
 
 ---
 

--- a/docs/safety/csmf/third-party-tools-safety-assmt.md
+++ b/docs/safety/csmf/third-party-tools-safety-assmt.md
@@ -8,15 +8,33 @@ tags:
 
 # Third Party Tools Safety
 
-This section documents the steps taken in order to minimise risk incurred from using third party tools in our software stack. Each of the tools is selected
+This section documents the steps taken to minimise the risk incurred from using third-party tools in our software stack. Each tool is selected on the basis of its maturity, breadth of community adoption, active maintenance, security track record and licence compatibility, and each dependency is version-pinned and updated under change control, with known-vulnerability monitoring provided through GitHub.
 
-## List of Third Party Tools
+A deliberate safety design decision underpins this assessment: the single most safety-critical component — the centile/SDS calculation itself — is performed by the RCPCH's **own** `rcpchgrowth` library (first-party, open source, maintained under this same Quality Management System), rather than by any third-party dependency. Third-party tools are relied upon for non-calculation concerns such as the web framework, chart rendering, hosting and source control.
 
-Python
-FastAPI
-React.js
+## Criticality classification
 
-## Cloud Services Providers
+| Criticality | Meaning |
+| ----------- | ------- |
+| **Critical** | A failure or defect could directly contribute to an incorrect or misleading clinical output, or to the unavailability of the service. |
+| **Supporting** | Supports delivery of the service but does not itself perform clinical calculation; a failure is unlikely to directly cause clinical harm. |
+| **Low** | No realistic safety impact (e.g. cosmetic or developer-only tooling). |
 
-Microsoft Azure
-GitHub
+## Software libraries and frameworks
+
+| Component | Purpose | Source | Criticality | Safety considerations and controls |
+| --------- | ------- | ------ | ----------- | ---------------------------------- |
+| `rcpchgrowth` | The RCPCH's own Python library, which performs the centile and SDS calculations (LMS method) that the API returns | RCPCH (first-party, open source) | **Critical** | The most safety-critical component. Authored and maintained in-house under this QMS; validated against the ~4000-child static test harness (see the [Clinical Safety Case Report](clinical-safety-case-report.md) hazard "Incorrect centile data is _returned by_ the API"); fully auditable; input-range validation is built in (see hazard "Wrong units of measurement"). |
+| Victory | Charting library used by the RCPCH React component library to render the growth-chart plots | Formidable Labs (open source), pinned to `victory@37.3.x` | **Critical** | Renders the visual chart that clinicians interpret. The data plotted is calculated upstream by `rcpchgrowth` and only visualised here. Pinned to an exact version; rendering regressions are caught by the component library's automated tests and Storybook visual review. |
+| Python | Programming language for the API and the `rcpchgrowth` library | Python Software Foundation (open source) | Supporting | Mature, widely used language; versions pinned; security updates tracked. The clinical calculation logic lives in `rcpchgrowth`, not in the language runtime. |
+| FastAPI | Web framework exposing the API endpoints (routing, request validation, OpenAPI schema) | Open source | Supporting | Handles request/response and input validation but performs no clinical calculation. Version-pinned; widely adopted; actively maintained. |
+| React / react-dom | General-purpose UI rendering framework consumed by the React component library | Meta (open source), **peer dependency** | Low | Provided by the **implementer's** host application as a peer dependency, and performs no clinical calculation. Not classified as safety-critical. |
+| styled-components | Component styling within the React component library | Open source | Low | Cosmetic; no safety impact. |
+
+## Cloud services and infrastructure providers
+
+| Provider | Purpose | Criticality | Safety considerations and controls |
+| -------- | ------- | ----------- | ---------------------------------- |
+| Microsoft Azure | Hosting and compute for the API server (WebApp), in a UK data centre | **Critical** (availability) | High-availability public cloud, hardened to above industry standard. Relevant to the hazard "Unavailability of the dGC API" (#51), whose residual risk is rated acceptable because immediate fallback methods (e.g. printed charts) exist. |
+| Azure API Management | API gateway / proxy in front of the API server (routing, throttling, access control) | **Critical** (availability) | A failure of proxying through API Management is one of the documented causes considered in hazard #51. |
+| GitHub | Source control, CI/CD, issue tracking, and the substrate for the QMS itself | **Critical** | Hosts the code, the Hazard Log (Issues), change control (Git commit history) and the approval workflow (Pull Requests). Access is controlled and branch protection enforces review before changes reach the `live` branch. |

--- a/docs/safety/medical-device-reg/essential-req.md
+++ b/docs/safety/medical-device-reg/essential-req.md
@@ -48,13 +48,49 @@ The manufacturer will need to determine which apply to their software by reviewi
 
 ## This information comprises the details on the label and the data in the instructions for use
 
-**13.3** The label must bear the following particulars.
+**13.3** The label must bear the following particulars. For this software device the "label" comprises the identifying information presented in this documentation and in the API/service metadata; particulars that concern physical product attributes are recorded as not applicable.
 
-**13.6** Where appropriate, the instructions for use must contain the following particulars:
+**(a)** the name or trade name and address of the manufacturer — _applies._ The manufacturer is the RCPCH, identified in this documentation.
 
-**(c)** if the device must be installed with or connected to other medical devices or equipment in order to operate as required for its intended purpose, sufficient details of its characteristics to identify the correct devices or equipment to use in order to obtain a safe combination;
+**(b)** the details strictly necessary to identify the device and the contents of the packaging, especially for the users — _applies._ The device is identified as the RCPCH Digital Growth Charts Platform, with the specific software version exposed through the API and its OpenAPI specification.
 
-**d)** all the information needed to verify whether the device is properly installed and can operate correctly and safely, plus details of the nature and frequency of the maintenance and calibration needed to ensure that the devices operate properly and safely at all times;
+**(c)** where appropriate, the word 'STERILE' — _not applicable to software._
+
+**(d)** where appropriate, the batch code (preceded by 'LOT') or the serial number — _not applicable in the physical sense; the software version identifier provides the equivalent traceability._
+
+**(e)** where appropriate, an indication of the date by which the device should be used safely, expressed as the year and month — _not applicable to software._
+
+**(f)** where appropriate, an indication that the device is for single use — _not applicable to software._
+
+**(g)** if the device is custom-made, the words 'custom-made device' — _not applicable._
+
+**(h)** if the device is intended for clinical investigations, the words 'exclusively for clinical investigations' — _not applicable._
+
+**(i)** any special storage and/or handling conditions — _not applicable to software._
+
+**(j)** any special operating instructions — _applies._ Provided in this documentation, which constitutes the Instructions for Use.
+
+**(k)** any warnings and/or precautions to take — _applies._ Provided in the [Intended Use](../csmf/clinical-safety-case-report.md#intended-use) section, the associated disclaimer, and throughout this documentation.
+
+**(l)** the year of manufacture for active devices (this indication may be included in the version or release identifier) — _applies via the release and version history recorded in the change-control system._
+
+**(m)** where applicable, the method of sterilisation — _not applicable to software._
+
+**(n)** where the device incorporates, as an integral part, a medicinal substance or a human blood derivative, the relevant statement — _not applicable._
+
+**13.6** Where appropriate, the instructions for use must contain the following particulars. For this software device the documentation site constitutes the instructions for use. Only the particulars relevant to a software device with a measuring function are reproduced below.
+
+**(a)** the details referred to in Section 13.3 (other than those, such as the batch code, that relate only to a physical label) — _applies;_ provided through this documentation.
+
+**(b)** the performances referred to in Section 3 and any undesirable side-effects — _applies;_ the intended performance is the calculation and display of growth-related parameters, as described in the System Definition and Intended Use sections of the [Clinical Safety Case Report](../csmf/clinical-safety-case-report.md).
+
+**(c)** if the device must be installed with or connected to other medical devices or equipment in order to operate as required for its intended purpose, sufficient details of its characteristics to identify the correct devices or equipment to use in order to obtain a safe combination — _applies;_ the platform is intended to be integrated within host systems (EPRs, EHRs and PHRs), and integration guidance is provided in the implementer documentation.
+
+**(d)** all the information needed to verify whether the device is properly installed and can operate correctly and safely, plus details of the nature and frequency of the maintenance and calibration needed to ensure that the devices operate properly and safely at all times — _applies;_ covered by the implementer and API documentation.
+
+**(q)** the degree of accuracy claimed for devices with a measuring function — _applies;_ the platform has a measuring function, and its accuracy is evidenced by the static validation of the calculation engine against a synthetic test harness of approximately 4000 children's data, supervised by Prof Tim Cole, as described in the [Clinical Safety Case Report](../csmf/clinical-safety-case-report.md) (hazard "Incorrect centile data is _returned by_ the API").
+
+The intervening particulars (e)–(p), which concern matters such as implantation, reuse, sterile packaging, radiation emission, and incorporated medicinal or animal-derived substances, are not applicable to this software device.
 
 ## The following are possibly applicable to software devices
 


### PR DESCRIPTION
## Summary

Phase 1 of the QMS / medical-device documentation hardening: complete the incomplete hazard entries in the Clinical Safety Case Report, restore lost content, and harden two related documents.

## Clinical Safety Case Report

- Restored the mangled **Outcome** table and the corrupted boundary between the Unavailability and Misuse hazards.
- Backfilled every blank **Severity / Likelihood / Residual Risk Level / Outcome** field from the authoritative GitHub issue labels, mapped through the DCB0129 5×5 risk matrix (residual, post-mitigation):

  | Hazard | Severity / Likelihood | Residual risk |
  |---|---|---|
  | Unavailability (#51) | Minor / Low | Level 1 – Acceptable |
  | Wrong data entered (#48) | Minor / Low | Level 1 – Acceptable |
  | Wrong units (#88) | Minor / Low | Level 1 – Acceptable |
  | Incorrect centile (#49) | Major / Very Low | Level 2 – Acceptable |
  | Misuse of API (#50) | Minor / Medium | Level 2 – Acceptable |

- Added the previously-missing **"Wrong units of measurement"** hazard (#88).
- Expanded each hazard's mitigation narrative from the source issues, including the per-cause mitigations for Unavailability (#51).

## Third-party tools safety (`third-party-tools-safety-assmt.md`)

- Replaced the bare stub with a **criticality-rated supplier register**. Removed React from the safety-critical set (UI peer dependency, performs no calculation); added **Victory** (`victory@37.3.x`), which renders the charts in the React component library.

## Essential Requirements (`essential-req.md`)

- Populated the empty **§13.3 (label)** and **§13.6 (instructions-for-use)** particulars, curated for software applicability; fixed a `d)` → `(d)` typo.

## Hazard-log housekeeping (applied to the issues)

- Restored the lost mitigation section on issue #49 → **#116 resolved/closed**.
- Reconciled risk-level labels so the issues match the matrix and this report: #88 `3 → 1`; #49 and #50 given `risk-level-2-acceptable`.

## Validation

`pymarkdown` lint, `codespell`, and `zensical build` all pass; cross-page links and the `#intended-use` anchor verified in the rendered output.

Refs #48 #49 #50 #51 #88 #116