### PR TITLE
docs(qms): Phase 2 — reframe medical-device regulation docs from EU to UK

### DIFF
--- a/docs/safety/medical-device-reg/doc-api.md
+++ b/docs/safety/medical-device-reg/doc-api.md
@@ -8,13 +8,13 @@ tags:
 
 # Declaration of Conformity (API Server)
 
-## EU DECLARATION OF CONFORMITY
+## UK DECLARATION OF CONFORMITY
 
 1. ### Unique identification of the product
 
 The Royal College of Paediatrics and Child Health Digital Growth Charts Application Programming Interface **Server**, all versions. <https://github.com/rcpch/digital-growth-charts-server>
 
-1. ### Name and address of the manufacturer or his authorised representative
+1. ### Name and address of the manufacturer or the UK Responsible Person
 
 The Royal College of Paediatrics and Child Health (RCPCH), 5-11 Theobalds Road, London, WC1X 8SH (telephone: +44 (0)20 7092 6000).
 
@@ -28,11 +28,13 @@ There is no image, this is an entirely software product, with no dedicated hardw
 
 Server application code is located at <https://github.com/rcpch/digital-growth-charts-server>
 
-1. ### The object of the declaration described in point 4 is in conformity with the relevant Union harmonisation legislation
+1. ### The object of the declaration described in point 4 is in conformity with the relevant UK legislation
 
-* Regulation (EU) 2017/745 - Medical Devices
+* The Medical Devices Regulations 2002 (SI 2002/618), as amended.
 
-1. ### References to the relevant harmonised standards used, or references to the specifications in relation to which conformity is declared
+The RCPCH Digital Growth Charts API Server is a **Class I** medical device, UKCA-marked under the above Regulations and registered with the MHRA (GMDN 65712). As a Class I device, conformity is self-declared by the manufacturer and no UK Approved Body assessment is required.
+
+1. ### References to the relevant designated standards used, or references to the specifications in relation to which conformity is declared
 
 1. ### Technical file
 
@@ -42,7 +44,7 @@ The complete unabridged technical file, all documentation, instructions for use,
 | --------------------------- | ------------------------------------------------------------------------------- |
 | Signed for and on behalf of | The Royal College of Paediatrics and Child Health                               |
 | Place of Issue              | Cawood, North Yorkshire, UK                                                     |
-| Date of Issue               | 7th May 2021                                                                    |
+| Date of Issue               | 26th June 2026                                                                  |
 | Name                        | Dr Marcus Baw                                                                   |
 | Position                    | Lead Developer, Clinical Safety Officer, GP and EM Clinician.                   |
 | Signature                   | ![doc-signature](../../_assets/_images/marcus-signature-only-used-for-docs.jpg) |

--- a/docs/safety/medical-device-reg/mdr-technical-docs.md
+++ b/docs/safety/medical-device-reg/mdr-technical-docs.md
@@ -6,11 +6,11 @@ tags:
   - Medical Device Regulation
 ---
 
-# Technical Documentation for EU Medical Device Regulation
+# Technical Documentation for UK Medical Device Regulation
 
 ## Digital Growth Charts Project
 
-1. ### Your name and address, or those of any authorised representatives
+1. ### Your name and address, or those of any UK Responsible Person
 
 The Royal College Of Paediatrics and Child Health (RCPCH), 5-11 Theobalds Road, London, WC1X 8SH (telephone: +44 (0)20 7092 6000).
 
@@ -34,7 +34,7 @@ The product was designed and developed entirely remotely by a geographically dis
 
 The 'place of manufacture' of the product could be most accurately said to be the code collaboration platform [GitHub](https://github.com/), and the primary tooling used in the manufacture was Microsoft Visual Studio Code.
 
-1. ### The name and address of any notified body involved in assessing the conformity of the product
+1. ### The name and address of any Approved Body involved in assessing the conformity of the product
 
 **Not Applicable** due to the Class I designation of the Device
 
@@ -42,9 +42,9 @@ The 'place of manufacture' of the product could be most accurately said to be th
 
 **Not Applicable** due to the Class I designation of the Device
 
-1. ### The EU declaration of conformity
+1. ### The UK declaration of conformity
 
-See [Declaration of Confomity](doc-api.md)
+See [Declaration of Conformity](doc-api.md)
 
 1. ### Label and instructions of use
 
@@ -52,7 +52,11 @@ All instructions for use are contained within [this documentation website](https
 
 1. ### A statement of relevant regulations to which the product complies
 
-* Regulation (EU) 2017/745 - Medical Devices
+* The Medical Devices Regulations 2002 (SI 2002/618), as amended.
+
+!!! note "EU market — a future consideration"
+
+    The device is currently placed on the Great Britain market under the UK Medical Devices Regulations 2002 as a **Class I** device, UKCA-marked and registered with the MHRA. Conformity with the EU Medical Device Regulation (Regulation (EU) 2017/745) — under which this software would likely be classified higher (Class IIa or above) and require assessment by an EU Notified Body — is a future consideration for any EU-market deployment and is not currently in scope.
 
 1. ### Identification of technical standards with which compliance is claimed
 
@@ -76,6 +80,6 @@ There are no technical standards pertaining directly to the manufacture of this 
 
     Automated tests on the programs are run on every code change. If the tests fail then the new code cannot be incorporated into the program, and the previous version will remain in place.
 
-    Tests can be viewed in the `test/` directory within each repository.
+    Tests can be viewed in the `tests/` directory within each repository.
 
     All repositories are listed at <https://github.com/rcpch>

--- a/docs/safety/medical-device-reg/mhra.md
+++ b/docs/safety/medical-device-reg/mhra.md
@@ -24,4 +24,4 @@ Determination of the class of medical device applicable was performed using the 
 
 ## UK Responsible Person
 
-- [Information of Responsible Persons](https://www.gov.uk/guidance/regulating-medical-devices-in-the-uk#responsible)
+A [UK Responsible Person](https://www.gov.uk/guidance/regulating-medical-devices-in-the-uk#responsible) is required only for manufacturers established **outside** the UK who wish to place a medical device on the Great Britain market. The RCPCH is established in the United Kingdom and therefore acts as the manufacturer, registering the device directly with the MHRA. A separate UK Responsible Person is **not applicable**.


### PR DESCRIPTION
## QMS Hardening — Phase 2: UK regulatory correctness

Part of the QMS / medical-device documentation hardening roadmap (follows Phase 1, #166). This phase corrects the EU framing of the medical-device regulation docs to the **UK** regime that actually applies: the dGC Platform is placed on the Great Britain market under the **UK Medical Devices Regulations 2002 (SI 2002/618)** as a **Class I, UKCA-marked, MHRA-registered** device (GMDN 65712) — *not* under EU MDR 2017/745.

### Changes

**`doc-api.md` (Declaration of Conformity)**
- "EU Declaration of Conformity" → "UK Declaration of Conformity"
- Cite **UK MDR 2002 (SI 2002/618), as amended** instead of *Regulation (EU) 2017/745*
- "relevant Union harmonisation legislation" → "relevant UK legislation"
- "harmonised standards" → "designated standards" (UK term)
- "authorised representative" → "UK Responsible Person"
- Added a clarifying statement: Class I, UKCA-marked, self-declared conformity, no UK Approved Body required
- Refreshed **Date of Issue** 7th May 2021 → **26th June 2026** (signature retained)

**`mdr-technical-docs.md` (Technical Documentation)**
- Title "for EU Medical Device Regulation" → "for UK Medical Device Regulation"
- "notified body" → "Approved Body" (UK equivalent)
- "EU declaration of conformity" → "UK declaration of conformity"
- Cite UK MDR 2002 instead of Regulation (EU) 2017/745
- Added an **"EU market — a future consideration"** note (EU MDR conformity deferred; would likely be Class IIa+ requiring an EU Notified Body)
- Fixed "Confomity" typo and corrected `test/` → `tests/` directory reference

**`mhra.md` (UK Medical Device Registration)**
- Clarified that a **UK Responsible Person is not applicable**, since RCPCH is a UK-established manufacturer registering directly with the MHRA (a UK Responsible Person is only required for non-UK manufacturers)

### Validation
- `codespell` — clean
- `pymarkdown` lint — clean
- `zensical build` — "No issues found" (includes link validation)

This PR is independent of #166 (no file overlap).