### PR TITLE
docs(qms): Phase 3 — ISO/IEC alignment & QMS documents

### DIFF
--- a/docs/safety/csmf/clinical-evaluation.md
+++ b/docs/safety/csmf/clinical-evaluation.md
@@ -1,0 +1,89 @@
+---
+title: Clinical Evaluation Report
+reviewers: Dr Marcus Baw, Dr Simon Chapman
+audience: clinical-safety, clinicians
+tags:
+  - Clinical Safety
+  - Medical Device Regulation
+---
+
+# Clinical Evaluation Report
+
+This is a **lightweight Clinical Evaluation Report (CER)** for the RCPCH Digital Growth Charts (dGC) Platform, drawn together from existing evidence. It assesses whether the Platform achieves its [Intended Purpose](intended-purpose.md) safely and effectively, as required in support of the [Essential Requirements](../medical-device-reg/essential-req.md) under the UK Medical Devices Regulations 2002.
+
+!!! info "Proportionate to a Class I calculation device"
+    Clinical evaluation for the dGC Platform is unusual: the device does not introduce a *new* clinical method, it **faithfully computes an existing, published, peer-reviewed clinical standard** (the national growth references). The central question of clinical evaluation is therefore principally one of **computational fidelity** — does the software return the correct value the reference defines? — supported by clinical oversight of the choice and application of those references. This report is structured accordingly.
+
+## 1. Scope
+
+This CER covers the dGC Platform as defined in the [Intended Purpose](intended-purpose.md): the API server and associated charting components that calculate and present childhood growth parameters (centiles and SDS) against recognised growth references.
+
+## 2. Device description and intended purpose
+
+See the canonical [Intended Purpose](intended-purpose.md) statement. In summary, the Platform is decision-support software that assists a trained healthcare professional by calculating and plotting a child's growth measurements against the clinically appropriate reference. It is not diagnostic and is one input among many in a clinical assessment.
+
+## 3. Clinical background and state of the art
+
+Plotting a child's measurements on a population growth reference is long-established, standard clinical practice in child health. The references used by the Platform are the recognised national and international standards:
+
+- **UK-WHO** growth references (combining WHO standards for early childhood with UK data);
+- **UK90** reference;
+- specialist **Trisomy-21 (Down syndrome)** and **Turner syndrome** references for use where those conditions have been diagnosed.
+
+These references are constructed using the **LMS method** (Cole & Green), the internationally accepted statistical method for summarising the distribution of a measurement by age as three smooth curves (L, M, S) from which any centile or SDS can be derived. The state of the art is well-defined, stable and published in the peer-reviewed literature; see [Growth references](../../clinician/growth-references.md) and [Growth chart papers](../../clinician/growth-chart-papers.md).
+
+The Platform's contribution is to make these references available **digitally and reproducibly** via an API, removing the transcription and plotting errors associated with manual chart use, while keeping interpretation firmly with the clinician.
+
+## 4. Evaluation method and evidence sources
+
+The clinical evidence for the Platform comes from four complementary sources:
+
+1. **Validity of the underlying references** — the references are themselves published, peer-reviewed clinical standards in routine national use; their clinical validity is established independently of this Platform.
+2. **Computational verification** — evidence that the software returns the values the references define (the test harness).
+3. **Expert clinical oversight** — governance of the choice and application of references by a standing expert clinical body.
+4. **Post-market experience** — real-world use and feedback (see [Post-Market Surveillance](pms-plan.md)).
+
+## 5. Clinical evidence
+
+### 5.1 Computational fidelity — the static test harness
+
+The single most important piece of evidence is the **~4000-child static test harness**. Because the LMS calculation is deterministic, a fixed dataset of children with known expected outputs provides **mathematically reproducible** proof that the API returns the correct centile/SDS for each case. The harness runs in continuous integration, so any regression introduced by a code or dependency change is detected before release. This provides a level of objective, repeatable accuracy evidence that is difficult to achieve for many other classes of medical software (see [Software Lifecycle](software-lifecycle.md#verification-and-validation-summary)).
+
+### 5.2 Statistical and clinical validation
+
+The Platform and its underlying [`rcpchgrowth`](../../developer/rcpchgrowth.md) library have been developed and reviewed with the involvement of leading subject-matter experts, including **Professor Tim Cole** (originator of the LMS method and a principal author of the UK growth references) and consultant paediatric input from **Dr Simon Chapman** (paediatric diabetes and endocrinology). This ongoing statistician and clinician involvement provides expert assurance that the references are implemented and applied correctly.
+
+### 5.3 Clinical governance and oversight
+
+Throughout the project, clinical oversight and the direction of safety evaluation were provided by the formal **Growth Charts Project Board**, a clinical expert group comprising senior RCPCH leadership and eminent clinicians in the field of growth (see [the team](../../about/team.md)). The Project Board decided all changes to the *nature* of the growth charts (for example, the application of gestational-age correction throughout the chart). This governance function is being formalised and strengthened: in **2026–27** it is being replaced by an official **RCPCH Growth Charts Committee**, providing a durable, accountable body for ongoing clinical oversight.
+
+### 5.4 Open peer review
+
+The entire codebase, including the calculation library, is open source. This enables independent replication and challenge of the calculations and testing by external specialists — a continuous, open analogue of academic peer review — and supports ongoing engagement with the international state of the art, including recent activity concerning WHO growth references in the underlying library.
+
+### 5.5 Post-market experience
+
+To date there have been **no reports of inaccuracy or of methodological or mathematical error** in the growth chart calculations. Feedback channels and the surveillance approach are described in the [Post-Market Surveillance](pms-plan.md) plan.
+
+## 6. Benefit–risk assessment
+
+The clinical **benefits** — accurate, reproducible, transcription-error-free calculation and presentation of growth parameters against validated national references, embedded directly in clinical systems — are clear and directly support safe child health monitoring.
+
+The principal residual **risks** (an incorrect value being returned, or the service being unavailable) are documented in the [Hazard Log](hazard-log.md) and rated **acceptable** after mitigation, owing to the deterministic test harness, the first-party validated calculation library, the conspicuousness of gross errors against a child's trajectory, and the availability of fallback methods. Interpretation always rests with a trained clinician who treats the chart as one input among many.
+
+The benefit–risk balance is therefore **favourable**.
+
+## 7. Conclusion
+
+On the available evidence, the dGC Platform achieves its intended purpose: it correctly and reproducibly computes recognised, peer-reviewed national growth references and presents them to support clinical assessment, with a favourable benefit–risk profile and robust, objective verification of computational accuracy.
+
+## 8. Ongoing clinical evaluation
+
+This CER is a living document. It is reviewed:
+
+- at each [management review](../qms.md#management-review);
+- on establishment of the RCPCH Growth Charts Committee (2026–27) and thereafter under its governance;
+- when a new growth reference is added or an existing calculation method materially changes;
+- in response to any post-market signal indicating a possible inaccuracy.
+
+The Git commit history of this file is its version record.

--- a/docs/safety/csmf/clinical-risk-mgmt-plan.md
+++ b/docs/safety/csmf/clinical-risk-mgmt-plan.md
@@ -204,6 +204,27 @@ Security issues may be responsibly disclosed to <growth.digital@rcpch.ac.uk> for
 
 Internally we treat security issues with the highest priority. Once the 'acute phase' of any security threat is handled, we will then follow the Safety Incident Management Process, usually converting to a public GitHub Issue.
 
+## ISO 14971 Alignment
+
+Our risk management is conducted natively in **DCB0129** terms, using the DCB0129 5×5 severity/likelihood scales and risk-acceptability matrix, because DCB0129 is the standard expected by our primary (UK/NHS) audience. **ISO 14971:2019** is the international standard for the application of risk management to medical devices, referenced by the UK Medical Devices Regulations 2002 and by our [Quality Management System](../qms.md).
+
+The two are not in conflict: they describe the same risk-management lifecycle, and the DCB0129 scales satisfy ISO 14971's requirement to define explicit criteria for risk estimation and acceptability. Rather than re-frame our risk documents, we map our existing DCB0129 process onto the ISO 14971 process below.
+
+| ISO 14971:2019 activity | How it is satisfied in our DCB0129 process |
+| ----------------------- | ------------------------------------------ |
+| Risk management plan | This [Clinical Risk Management Plan](#purpose) and the [Clinical Risk Management System](clinical-risk-mgmt-system.md) |
+| Intended use / reasonably foreseeable misuse | [Intended Purpose](intended-purpose.md) statement |
+| Identification of hazards | Hazard identification workshops; the [Hazard Log](hazard-log.md) |
+| Estimation of risk(s) | DCB0129 **severity (1–5) × likelihood (1–5)** recorded per hazard |
+| Risk evaluation (acceptability) | DCB0129 risk-acceptability **matrix** (Levels 1–5) |
+| Risk control | Mitigations recorded against each hazard in the Hazard Log |
+| Residual risk evaluation | Post-mitigation severity/likelihood recorded per hazard |
+| Overall residual risk acceptability | Benefit–risk argument in the [Clinical Safety Case Report](clinical-safety-case-report.md) |
+| Risk management report | [Clinical Safety Case Report](clinical-safety-case-report.md) |
+| Production & post-production information | [Post-Market Surveillance](pms-plan.md) plan |
+
+Software-specific risk management additionally follows IEC 62304 (software safety **Class B**); see [Software Lifecycle](software-lifecycle.md).
+
 ## Clinical Safety Competence and Training
 
 ### Overview

--- a/docs/safety/csmf/intended-purpose.md
+++ b/docs/safety/csmf/intended-purpose.md
@@ -1,0 +1,62 @@
+---
+title: Intended Purpose
+reviewers: Dr Marcus Baw, Dr Simon Chapman
+audience: clinical-safety, clinicians, implementers
+tags:
+  - Clinical Safety
+  - Medical Device Regulation
+---
+
+# Intended Purpose
+
+This is the canonical **Intended Purpose** statement for the RCPCH Digital Growth Charts (dGC) Platform. It is the single authoritative source referenced by the [Clinical Safety Case Report](clinical-safety-case-report.md), the [Technical Documentation](../medical-device-reg/mdr-technical-docs.md), the [Clinical Evaluation Report](clinical-evaluation.md), and the risk management process. Where any other document summarises the intended use, this statement takes precedence.
+
+!!! info "Why a standalone statement?"
+    Under ISO 13485, ISO 14971 and the UK Medical Devices Regulations 2002, the intended purpose is foundational: it scopes the risk analysis, the clinical evaluation and the technical documentation. Stating it once, canonically, ensures these documents remain consistent with one another.
+
+## Intended purpose statement
+
+The RCPCH Digital Growth Charts Platform is **software intended to assist a suitably qualified healthcare professional** by calculating and presenting a child's growth parameters — including the centile and standard deviation score (SDS / z-score) for height/length, weight, head circumference, body mass index (BMI), and related measures — relative to a recognised growth reference, and by plotting these values on the corresponding growth chart.
+
+The output is intended to **support**, not replace, the clinical assessment, interpretation and decision-making of the healthcare professional.
+
+## Intended medical indication
+
+The Platform is intended to support the monitoring of childhood growth, assisting clinicians in detecting children who may be developing underweight, overweight, short or tall stature, abnormal head growth, or other growth-related disorders, so that appropriate further clinical assessment can be undertaken.
+
+The Platform does **not** itself provide a diagnosis. A growth measurement, centile or chart is only **one** of many sources of information available to a clinician, and must be interpreted as **part** of a full clinical assessment.
+
+## Intended users
+
+The intended user is a **healthcare professional** with sufficient training and knowledge to understand the meaning of the values and charts presented, and to interpret them in clinical context.
+
+Growth charts have long appeared in the parent-held Personal Child Health Record ("Red Book"), and parents may freely be given access to charts. However, the **interpretation** of a growth trend remains a task for a clinician; parents are not the intended interpreting user.
+
+## Intended use environment
+
+The Platform is intended to be **embedded within other clinical software systems** — principally Electronic Patient Records (EPRs), Electronic Health Records (EHRs), Personal Health Records (PHRs) and similar platforms — which call the dGC API and present its results to the user through their own user interface, or which incorporate the RCPCH chart component.
+
+It is intended for use in the settings in which childhood growth is routinely assessed, including primary care, community child health, secondary and tertiary paediatric care.
+
+## Patient population
+
+The Platform is intended for use across the paediatric age range served by the supported growth references — from severely premature infants through to approximately 20 years of age — using the reference appropriate to the child (for example UK-WHO, UK90, and the specialist Trisomy-21 (Down syndrome) and Turner syndrome references). Selection of the clinically appropriate reference for a given child remains a clinical decision.
+
+## Limitations and exclusions
+
+!!! warning "What the Platform is not"
+    - It is **not** a diagnostic device and does not produce a diagnosis.
+    - It does **not** replace clinical judgement, examination, or the seeking of confirmatory evidence.
+    - It is **not** intended for independent, unsupervised interpretation by parents or other lay users.
+    - Specialist references (e.g. Down syndrome, Turner syndrome) require that the relevant condition has already been diagnosed by appropriate clinical means; see [Turner and Down syndrome charts](../../integrator/turner-down-syndrome.md).
+
+Clinicians must actively seek other confirmatory evidence for any conclusion reached with the assistance of a growth chart.
+
+## Warranted service
+
+!!! warning "Only the official RCPCH API service is warranted"
+    **Only the commercial subscription API service provided by the RCPCH** is warranted to have undergone the testing and assurance described in the [Clinical Safety Case Report](clinical-safety-case-report.md). Self-hosting, reverse-engineering, or otherwise using internal dGC components outside the official RCPCH Platform is deemed usage outside the provisions of this documentation, and the responsibility for clinical safety in such deployments rests with the deploying organisation under its own [DCB0160](clinical-risk-mgmt-system.md) assessment.
+
+## Regulatory classification
+
+The Platform is registered with the MHRA as a **Class I** medical device under the [UK Medical Devices Regulations 2002 (SI 2002/618), as amended](../medical-device-reg/mhra.md), under GMDN **65712 — Paediatric growth calculation API software**. For the determination of the IEC 62304 software safety class, see [Software Lifecycle (IEC 62304)](software-lifecycle.md).

--- a/docs/safety/csmf/pms-plan.md
+++ b/docs/safety/csmf/pms-plan.md
@@ -1,0 +1,65 @@
+---
+title: Post-Market Surveillance
+reviewers: Dr Marcus Baw, Dr Simon Chapman
+audience: clinical-safety, implementers
+tags:
+  - Clinical Safety
+  - Medical Device Regulation
+---
+
+# Post-Market Surveillance (PMS)
+
+Post-market surveillance is the proactive and reactive collection and review of real-world experience once the device is in use, so that the [Hazard Log](hazard-log.md), [Clinical Evaluation](clinical-evaluation.md) and [Clinical Safety Case](clinical-safety-case-report.md) stay current. This plan describes how the RCPCH conducts PMS for the Digital Growth Charts (dGC) Platform.
+
+!!! info "An open surveillance model"
+    Most of the dGC Platform's post-market surveillance happens **in the open**. Because development, issue tracking and discussion are public, the surveillance base is far wider than for a typical closed Health IT system — anyone, anywhere can inspect the code and raise a concern.
+
+## Purpose and scope
+
+This plan applies to the RCPCH-operated dGC Platform as defined in the [Intended Purpose](intended-purpose.md). It covers surveillance of clinical safety and performance (in particular, the accuracy of growth calculations and the availability of the service). Organisations self-hosting or otherwise deploying the software assume their own post-market responsibilities under [DCB0160](clinical-risk-mgmt-system.md).
+
+## Data sources monitored
+
+| Source | Type | What it tells us |
+| ------ | ---- | ---------------- |
+| **GitHub Issues** (public, across the [RCPCH repositories](https://github.com/rcpch)) | Reactive + proactive | The primary, open channel for bug reports, feature requests and safety concerns. Issues feed directly into the development workflow. |
+| **RCPCH forum** — [forum.rcpch.tech](https://forum.rcpch.tech) | Reactive + proactive | Open discussion with users, implementers and clinicians about implementation and safety. |
+| **Direct communication with implementers** | Reactive | Private email and messaging with subscribing implementers, used where a matter is not suitable for public discussion. |
+| **Security disclosures** — <growth.digital@rcpch.ac.uk> | Reactive | Responsible disclosure channel for security issues (see the [Clinical Risk Management Plan](clinical-risk-mgmt-plan.md#security-incident-management-process)). |
+| **State-of-the-art and literature review** | Proactive | Ongoing review of developments in growth-reference methodology and international standards, including activity concerning WHO growth references in the underlying [`rcpchgrowth`](../../developer/rcpchgrowth.md) library. |
+| **Service monitoring** | Proactive | Availability and operational monitoring of the API on Azure / Azure API Management. |
+
+## Process and cadence
+
+1. **Continuous intake.** Reports arrive at any time through the channels above. Anyone may raise a public GitHub Issue.
+2. **Triage.** Incoming reports are triaged as part of the two-weekly sprint planning, at which clinical safety is a standing agenda item (see the [Clinical Risk Management Plan](clinical-risk-mgmt-plan.md#clinical-risk-meetings)). Any report suggesting a safety concern is escalated to the Clinical Safety Officer immediately rather than waiting for the next sprint.
+3. **Assessment.** The CSO assesses whether a report indicates a new or changed hazard, a possible inaccuracy, or a reportable incident.
+4. **Action.** Outcomes may include: a code fix under change control; an update to the Hazard Log, Clinical Evaluation or this plan; or — where applicable — vigilance reporting (below).
+5. **Periodic review.** PMS data is reviewed in aggregate at each [management review](../qms.md#management-review), looking for trends not visible in individual reports.
+
+## Triggers for escalation
+
+A post-market signal triggers formal risk-management review (and, where indicated, a corrective action) when it suggests any of:
+
+- a possible inaccuracy or methodological error in a growth calculation;
+- a new hazard not currently in the Hazard Log, or a change to the likelihood or severity of an existing one;
+- a recurrent or systemic availability problem;
+- a security vulnerability affecting safety or data protection.
+
+## Vigilance — reporting to the MHRA
+
+A **serious incident** — any malfunction or inadequacy that has led, or could lead, to death or serious deterioration in health, or a serious public health threat — is reportable to the MHRA. The Person Responsible for Regulatory Compliance (PRRC) is responsible for assessing reportability and making any report within the required timelines. The incident-handling process is set out in the [Clinical Risk Management Plan](clinical-risk-mgmt-plan.md#safety-incident-management-process).
+
+## Surveillance summary to date
+
+!!! success "No reported inaccuracies to date"
+    As at the date of the most recent commit to this document, there have been **no reports of inaccuracy, nor of any mathematical or methodological error**, in the growth-chart calculations produced by the RCPCH dGC Platform. The continuous static test harness has likewise reported no calculation regressions.
+
+This summary stands as the Platform's current periodic safety position. A consolidated periodic safety review will be produced at least annually as part of, or alongside, the management review, summarising surveillance data, conclusions on safety and performance, and any resulting actions.
+
+## Roles and review
+
+- **PRRC / Clinical Safety Officer** — Dr Marcus Baw: owns PMS, vigilance reporting and the periodic safety position.
+- **Senior Clinical Adviser** — Dr Simon Chapman: clinical assessment of signals.
+
+This plan is reviewed at each management review and whenever the surveillance approach changes. The Git commit history of this file is its version record.

--- a/docs/safety/csmf/software-lifecycle.md
+++ b/docs/safety/csmf/software-lifecycle.md
@@ -1,0 +1,84 @@
+---
+title: Software Lifecycle (IEC 62304)
+reviewers: Dr Marcus Baw, Dr Simon Chapman
+audience: clinical-safety, developers
+tags:
+  - Clinical Safety
+  - Quality Management
+---
+
+# Software Lifecycle (IEC 62304)
+
+This document records how the RCPCH Digital Growth Charts (dGC) Platform satisfies the software lifecycle processes of **IEC 62304:2006+AMD1:2015** (*Medical device software — Software life cycle processes*), and records the formally determined **software safety classification**.
+
+!!! info "IEC 62304 software class vs UK MDR device class"
+    These are two **independent** classifications and are often confused:
+
+    - **UK MDR device class** (I / IIa / IIb / III) rates the *whole device's* risk and selects the regulatory route. The dGC Platform is [Class I](../medical-device-reg/mhra.md).
+    - **IEC 62304 software safety class** (A / B / C) rates the worst-case harm a *software failure* could cause, **assuming external risk-control measures fail**. It scales the rigour required of the software development process.
+
+    A device can be UK MDR Class I yet IEC 62304 Class B — they measure different things.
+
+## Software safety classification
+
+IEC 62304 defines three software safety classes based on the worst-case harm that could result from a software failure, assuming that any external (hardware, clinical, or procedural) risk-control measures also fail:
+
+| Class | Worst-case harm from software failure |
+| ----- | ------------------------------------- |
+| **A** | No injury or damage to health is possible |
+| **B** | Non-serious injury is possible |
+| **C** | Death or serious injury is possible |
+
+### Determination: Class B
+
+The dGC software is classified as **IEC 62304 Class B**.
+
+**Rationale.** The most safety-significant hazard in the [Hazard Log](hazard-log.md) is an *incorrect centile or SDS being returned by the API*, rated **Major** severity but **Very Low** likelihood, with strong external risk controls. In structured discussion with clinical experts, **no plausible scenario could be constructed in which death or serious injury results from the software's output**, because:
+
+- the growth chart is only **one input** among many in a clinical assessment, and is never solely determinative (see [Intended Purpose](intended-purpose.md));
+- the interpreting user is a trained healthcare professional who is expected to seek confirmatory evidence;
+- a single erroneous value is visibly discontinuous with the child's established growth trajectory, making gross errors conspicuous;
+- the calculation is performed by the RCPCH's own validated [`rcpchgrowth`](../../developer/rcpchgrowth.md) library and continuously checked against a large static test harness (see [Verification and validation](#verification-and-validation-summary)).
+
+For death or serious injury to occur, the software error would have to coincide with the simultaneous failure of **multiple independent clinical safeguards**. This places the software in Class B rather than Class C.
+
+Equally, the software is **not Class A**: we do not claim it is incapable of contributing to any harm. A sustained, non-obvious calculation error could, in principle, contribute to a delayed or inappropriate clinical decision and thus to non-serious harm.
+
+!!! success "Sign-off"
+    This Class B determination was agreed by the Clinical Safety Officer (Dr Marcus Baw) and the Senior Clinical Adviser (Dr Simon Chapman). The rationale is recorded here as a controlled document; the Git commit history is the change record. It is reviewed at each [management review](../qms.md#management-review) and whenever a change materially alters the hazard profile.
+
+### Consequences of Class B
+
+Class B requires the full software lifecycle process **except** the additional detailed-design rigour (IEC 62304 §5.4) reserved for Class C. The applicable processes are mapped below.
+
+## Lifecycle process mapping
+
+The dGC Platform is developed openly on GitHub. The IEC 62304 processes are satisfied by the project's existing, version-controlled development practices rather than by separate paperwork.
+
+| IEC 62304 process | How it is satisfied for the dGC Platform |
+| ----------------- | ---------------------------------------- |
+| **5.1 Development planning** | Work is planned in two-weekly sprints with clinical safety as a standing agenda item (see [Clinical Risk Management Plan](clinical-risk-mgmt-plan.md)); planning is tracked in GitHub Issues and Projects. |
+| **5.2 Requirements analysis** | Requirements are captured as GitHub Issues and as the published [API reference](../../integrator/api-reference.md) and [client specification](../../integrator/client-specification.md). Safety-relevant requirements derive from the Hazard Log. |
+| **5.3 Architectural design** | The Platform architecture (API server, `rcpchgrowth` calculation library, chart component) is documented across the [Products](../../products/products-overview.md) and [Contributors](../../developer/start-here.md) sections. Safety-by-design: clinical calculation is isolated in the first-party `rcpchgrowth` library. |
+| **5.4 Detailed design** | Not required at Class C rigour. Detailed design is expressed in the open source code itself and its docstrings. |
+| **5.5 Unit implementation & verification** | All code is open source. Unit tests accompany the code and run in CI on every change; code review via Pull Request is mandatory. |
+| **5.6 Integration & integration testing** | Automated integration tests run in CI; changes cannot be merged to a deployment branch unless tests pass. |
+| **5.7 System testing** | The API is tested end-to-end, including the **~4000-child static test harness** that provides mathematically reproducible evidence of calculation accuracy (see below). |
+| **5.8 Software release** | Releases are tagged Git commits, promoted through the branch strategy described in the [Clinical Risk Management Plan](clinical-risk-mgmt-plan.md#deployment-and-ongoing-maintenance). The `live` branch changes infrequently and only after review. |
+| **6 Maintenance** | Maintenance follows the same PR-and-review, CI-gated branch-promotion process as new development. Dependency updates are tracked and version-pinned. |
+| **7 Software risk management** | Performed under [ISO 14971 / DCB0129](clinical-risk-mgmt-plan.md#iso-14971-alignment) via the [Hazard Log](hazard-log.md). |
+| **8 Configuration management** | Git provides complete configuration management and an immutable change history; history is not rewritten on protected branches. |
+| **9 Problem resolution** | Problems are raised, triaged and resolved as public GitHub Issues, feeding the [post-market surveillance](pms-plan.md) process. |
+
+## SOUP (Software of Unknown Provenance)
+
+IEC 62304 requires that third-party software components ("SOUP") be identified and risk-assessed. For the dGC Platform this is recorded in the [Third Party Tools Safety](third-party-tools-safety-assmt.md) criticality register, which lists each component, its purpose, its criticality, and the controls applied. The single most safety-critical calculation is deliberately **not** SOUP — it is performed by the first-party `rcpchgrowth` library maintained under this QMS.
+
+## Verification and validation summary
+
+- **Automated test suite** — unit and integration tests run in continuous integration on every code change; failing tests block merge and release.
+- **Static test harness** — a reference dataset of approximately **4000 children** is used to verify that the API returns the expected centile/SDS values. Because the LMS calculation is deterministic, this harness provides **mathematically reproducible** evidence of accuracy and detects any regression introduced by a code or dependency change. This is the central piece of [clinical evaluation](clinical-evaluation.md) evidence.
+- **Code review** — every change is reviewed via Pull Request before reaching a deployment branch; the review comments form the verification record.
+- **Open peer review** — the entire codebase is open source and open to inspection and challenge by external specialists, in a manner analogous to academic peer review.
+
+Verification and validation evidence is maintained in the respective GitHub repositories under the [RCPCH organisation](https://github.com/rcpch).

--- a/docs/safety/qms.md
+++ b/docs/safety/qms.md
@@ -1,0 +1,140 @@
+---
+title: Quality Management System
+reviewers: Dr Marcus Baw, Dr Simon Chapman
+audience: clinical-safety, implementers, developers
+tags:
+  - Clinical Safety
+  - Quality Management
+  - Medical Device Regulation
+---
+
+# Quality Management System
+
+This page is the **quality manual** for the RCPCH's medical-device software activities. It describes the Quality Management System (QMS) maintained for the design, development, release and post-market surveillance of the RCPCH Digital Growth Charts (dGC) Platform, and maps the requirements of **ISO 13485:2016** to the place in this documentation, or the GitHub process, where each is satisfied.
+
+!!! info "Status"
+    **Standard:** ISO 13485:2016 · **UK framework:** UK Medical Devices Regulations 2002 (SI 2002/618, as amended) · **Owner:** Dr Marcus Baw (Clinical Safety Officer / PRRC) · **Status:** maintained as a controlled document; presented to the first formal [management review](#management-review). Version history is the Git commit history of this file — no separate version table is kept (see [Document and record control](#document-and-record-control)).
+
+## Purpose and scope
+
+The QMS exists to ensure that the dGC Platform is clinically safe, effective and fit for purpose. It is implemented primarily through **Git-based version control on GitHub**, supplemented by the structured clinical-safety and regulatory processes documented in this section.
+
+- **In scope:** all Software as a Medical Device (SaMD) registered with the MHRA under the RCPCH as manufacturer — currently the [dGC API Platform](csmf/intended-purpose.md) and its associated client components.
+- **Out of scope:** third parties deploying RCPCH open-source code under licence, who assume manufacturer/deployer responsibilities independently under their own [DCB0160](csmf/clinical-risk-mgmt-system.md) assessment.
+
+The dGC Platform is the RCPCH's only SaMD product today. As further products follow, generalisable patterns from this QMS are intended to be extracted into a shared template.
+
+## Normative references
+
+| Standard | Application |
+| -------- | ----------- |
+| ISO 13485:2016 | Quality management systems for medical devices |
+| ISO 14971:2019 | Risk management — mapped from our [DCB0129 risk process](csmf/clinical-risk-mgmt-plan.md#iso-14971-alignment) |
+| IEC 62304:2006+AMD1:2015 | [Software lifecycle](csmf/software-lifecycle.md) — software safety **Class B** |
+| DCB0129 / DCB0160 | NHS clinical risk management (manufacture / deployment) |
+| UK MDR 2002 (SI 2002/618, as amended) | UK regulatory framework — [MHRA registration](medical-device-reg/mhra.md) |
+
+## Organisational roles
+
+| Role | Responsibility | Postholder |
+| ---- | -------------- | ---------- |
+| **PRRC / Clinical Safety Officer** | Overall regulatory compliance; ISO 14971 / DCB0129 risk management; MHRA liaison; Declaration of Conformity | Dr Marcus Baw |
+| **Technical Lead** | IEC 62304 software lifecycle; release management; security | Michael Barton |
+| **Clinical Lead** | Clinical evaluation; intended-purpose definition; usability | Dr Marcus Baw & Dr Simon Chapman |
+| **QMS Administrator** | Document control; audit scheduling; training records | Dr Marcus Baw |
+
+### Person Responsible for Regulatory Compliance (PRRC)
+
+The RCPCH designates a **Person Responsible for Regulatory Compliance (PRRC)** — a role adopted from medical-device regulatory good practice — who ensures that the technical documentation is kept up to date, that post-market surveillance and reporting obligations are met, and that the [Declaration of Conformity](medical-device-reg/doc-api.md) is accurate. The PRRC for the dGC Platform is **Dr Marcus Baw**.
+
+### Competence and training
+
+Clinical-safety activities are undertaken by competent staff (see the [Clinical Risk Management Plan](csmf/clinical-risk-mgmt-plan.md#clinical-safety-competence-and-training)). It is a matter of public record that:
+
+- **Dr Marcus Baw** is an NHS Digital-trained Clinical Safety Officer and a registered medical practitioner (GMC 4712729);
+- **Dr Simon Chapman** is a consultant paediatrician (paediatric diabetes and endocrinology) and a trained Clinical Safety Officer.
+
+## Quality policy and objectives
+
+**Quality policy.** The RCPCH is committed to developing and maintaining SaMD that is clinically safe, effective and fit for purpose, achieved through transparent open-source development, rigorous clinical-safety management, and continuous improvement informed by real-world performance and user feedback.
+
+**Standing quality objectives:**
+
+- No unmitigated high or unacceptable risks in the [Hazard Log](csmf/hazard-log.md) at any release.
+- All serious incidents assessed for MHRA reportability and reported within required timelines.
+- Management review and internal audit each conducted at least annually.
+- Calculation accuracy continuously evidenced by the static test harness, with zero unresolved calculation regressions at release.
+
+## Document and record control
+
+All controlled documents — this manual, the clinical safety file, and the technical documentation — live in Git and are published on this site. The control mechanism is GitHub, not a manual document-control log:
+
+- Changes are proposed by **Pull Request** and require **at least one approving review** before merge to the protected `live` branch.
+- The **Git commit history is the complete, immutable change record** for every controlled document; history is not rewritten on `live`.
+- **Records** (hazards, incidents, complaints, decisions) are kept as GitHub Issues and commits and are retained indefinitely.
+
+This replaces traditional manual document controls, as described in the [Clinical Risk Management Plan](csmf/clinical-risk-mgmt-plan.md#document-controls).
+
+!!! note "Planned formalisation"
+    A `CODEOWNERS` rule requiring PRRC review for safety- and regulatory-critical documents, and a set of QMS GitHub Issue templates (complaint, CAPA, design-input, serious-incident, audit, management-review, hazard), are planned as the next increment of QMS formalisation. The underlying controls — mandatory review on `live` and open Issue-based records — are already in force.
+
+## Design and development
+
+Design and development follow the [IEC 62304 software lifecycle](csmf/software-lifecycle.md) (software safety **Class B**). In practice this is the project's open, CI-gated, branch-promotion workflow: requirements and design inputs are captured as GitHub Issues and published specifications; changes are implemented with accompanying automated tests; every change is peer-reviewed via Pull Request; and releases are tagged commits promoted to `live` only after verification. Verification and validation — including the **~4000-child static test harness** — are summarised in the [Software Lifecycle](csmf/software-lifecycle.md#verification-and-validation-summary) page.
+
+## Risk management
+
+Risk management follows **ISO 14971**, implemented through the **DCB0129** process and 5×5 risk matrix, with a [mapping between the two](csmf/clinical-risk-mgmt-plan.md#iso-14971-alignment). The risk management file comprises the [Clinical Risk Management System](csmf/clinical-risk-mgmt-system.md), the [Clinical Risk Management Plan](csmf/clinical-risk-mgmt-plan.md), the [Hazard Log](csmf/hazard-log.md) and the [Clinical Safety Case Report](csmf/clinical-safety-case-report.md). No release may proceed with an unmitigated risk rated high or unacceptable.
+
+## Purchasing and supplier management
+
+Suppliers whose products could affect device quality, safety or availability are assessed and monitored in the [Third Party Tools Safety](csmf/third-party-tools-safety-assmt.md) criticality register, which records each supplier's purpose, criticality and the controls applied. Critical suppliers are reviewed at management review.
+
+## Complaints and post-market surveillance
+
+Feedback and complaints arrive through open GitHub Issues, the [RCPCH forum](https://forum.rcpch.tech), and direct implementer communication, and are handled under the [Post-Market Surveillance](csmf/pms-plan.md) plan. Serious incidents are assessed for MHRA reportability by the PRRC under the [incident process](csmf/clinical-risk-mgmt-plan.md#safety-incident-management-process). Clinical performance is appraised in the [Clinical Evaluation Report](csmf/clinical-evaluation.md).
+
+## Management review
+
+A formal management review is conducted at least **annually**, and following any significant quality event. It reviews the quality policy and objectives, audit findings, complaints and PMS data, supplier status, regulatory changes, and actions from the previous review.
+
+!!! note "First management review"
+    A management review has not yet been formally conducted; the **first is planned**, and this QMS manual is being prepared for presentation to it.
+
+## Internal audit
+
+Internal audit verifies that the QMS conforms to ISO 13485 and is effectively implemented. The RCPCH already audits its software and quality process on an ongoing, informal basis (for example through continuous open code review and the static test harness); this manual **formalises that practice** into a documented annual audit cycle, with findings recorded as GitHub Issues and non-conformities driving corrective action.
+
+## ISO 13485:2016 clause mapping
+
+| ISO 13485 clause | Evidence location |
+| ---------------- | ----------------- |
+| 4.1 General QMS requirements | This page |
+| 4.2.1–4.2.2 Documentation / quality manual | This page |
+| 4.2.3 Medical device file | [Technical Documentation](medical-device-reg/mdr-technical-docs.md), [Essential Requirements](medical-device-reg/essential-req.md) |
+| 4.2.4 Document control | [Document and record control](#document-and-record-control); branch protection on `live` |
+| 4.2.5 Record control | GitHub Issues; Git commit history |
+| 5.1 / 5.3 Management commitment & quality policy | [Quality policy and objectives](#quality-policy-and-objectives) |
+| 5.2 Customer focus | [Post-Market Surveillance](csmf/pms-plan.md) |
+| 5.4 Planning | [Quality objectives](#quality-policy-and-objectives); management review |
+| 5.5 Responsibility & authority | [Organisational roles](#organisational-roles) |
+| 5.6 Management review | [Management review](#management-review) |
+| 6.2 Human resources | [Competence and training](#competence-and-training) |
+| 6.3 Infrastructure | [Supplier register](csmf/third-party-tools-safety-assmt.md) (Azure, APIM, GitHub) |
+| 7.1 Planning of product realisation | [Software Lifecycle](csmf/software-lifecycle.md) |
+| 7.2 Customer-related processes | [Intended Purpose](csmf/intended-purpose.md); [API reference](../integrator/api-reference.md) |
+| 7.3 Design and development | [Software Lifecycle](csmf/software-lifecycle.md) |
+| 7.4 Purchasing | [Supplier register](csmf/third-party-tools-safety-assmt.md) |
+| 7.5 Production & service provision | IEC 62304 lifecycle; release process |
+| 8.2.1 Feedback | [Post-Market Surveillance](csmf/pms-plan.md) |
+| 8.2.2 Complaint handling | [PMS plan](csmf/pms-plan.md); [incident process](csmf/clinical-risk-mgmt-plan.md#safety-incident-management-process) |
+| 8.2.3 Reporting to regulatory authorities | [Vigilance / MHRA reporting](csmf/pms-plan.md#vigilance-reporting-to-the-mhra) |
+| 8.2.4 Internal audit | [Internal audit](#internal-audit) |
+| 8.2.6 Monitoring & measurement of product | Static test harness; [Software Lifecycle](csmf/software-lifecycle.md#verification-and-validation-summary) |
+| 8.3 Control of nonconforming product | CI test gates; [incident process](csmf/clinical-risk-mgmt-plan.md#safety-incident-management-process) |
+| 8.4 Analysis of data | [PMS plan](csmf/pms-plan.md); management review |
+| 8.5 Improvement (CAPA) | [PMS plan](csmf/pms-plan.md); management review |
+
+## Review of this manual
+
+This manual is a controlled document under the QMS it describes. It is reviewed at each management review, following any significant regulatory change, following any internal-audit finding affecting the QMS itself, and when a new product is brought into scope. Changes are made by Pull Request; the Git commit history is the version record.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -72,11 +72,16 @@ nav:
       - "developer/contributing.md"
   - Clinical Safety:
       - "safety/overview.md"
+      - Quality Management System: "safety/qms.md"
       - Clinical Safety File:
           - "safety/csmf/clinical-risk-mgmt-system.md"
           - "safety/csmf/clinical-risk-mgmt-plan.md"
+          - "safety/csmf/intended-purpose.md"
           - "safety/csmf/clinical-safety-case-report.md"
           - "safety/csmf/hazard-log.md"
+          - "safety/csmf/software-lifecycle.md"
+          - "safety/csmf/clinical-evaluation.md"
+          - "safety/csmf/pms-plan.md"
           - "safety/csmf/third-party-tools-safety-assmt.md"
           - "safety/csmf/license.md"
       - DTAC:


### PR DESCRIPTION
## QMS Hardening — Phase 3: ISO/IEC alignment + missing documents

Third phase of the QMS / medical-device documentation hardening roadmap (follows Phase 1 #166 and Phase 2 #167). Delivered as a **single PR** covering the new structured documents that bring the clinical-safety / medical-device documentation into closer alignment with **ISO 13485**, **ISO 14971** and **IEC 62304**.

This PR is **independent of #166 and #167** — no file overlap, so no merge conflicts in any order.

### New documents (`docs/safety/`)

| Page | What it is |
|---|---|
| **`qms.md` — Quality Management System** | A navigable ISO 13485 quality manual mapped to the *real* GitHub-based process and the actual documentation pages, with an ISO 13485:2016 clause→page table. Roles populated (Technical Lead: Michael Barton; Clinical Lead: Marcus Baw & Simon Chapman; PRRC/CSO/QMS Admin: Marcus Baw). Honest about maturity — first management review *planned*, internal audit being *formalised*, CODEOWNERS / issue templates noted as *planned* (Phase 4). |
| **`csmf/intended-purpose.md` — Intended Purpose** | Standalone canonical Intended Purpose statement (extracted/expanded from the Clinical Safety Case Report), referenced by the technical file, CER and risk management. |
| **`csmf/software-lifecycle.md` — Software Lifecycle (IEC 62304)** | Formal software safety classification as **Class B** with documented rationale (agreed by CSO + Senior Clinical Adviser); IEC 62304 process mapping; SOUP; V&V summary including the ~4000-child static test harness. |
| **`csmf/clinical-evaluation.md` — Clinical Evaluation Report** | Lightweight CER from existing evidence: the test harness (mathematically reproducible accuracy), Prof Tim Cole / consultant clinician oversight, the Project Board → **RCPCH Growth Charts Committee (2026–27)**, open peer review, zero post-market inaccuracies to date. |
| **`csmf/pms-plan.md` — Post-Market Surveillance** | PMS plan: open GitHub Issues, the RCPCH forum, direct implementer comms, state-of-the-art review; surveillance-to-date summary (no reported inaccuracies); MHRA vigilance route. |

### Updated

- **`csmf/clinical-risk-mgmt-plan.md`** — adds an **ISO 14971 alignment** section mapping the existing **DCB0129** 5×5 process onto ISO 14971 (keeping DCB0129, per CSO decision — UK users expect it).
- **`mkdocs.yml`** — adds the new pages to the *Clinical Safety* navigation (new "Quality Management System" entry + four new Clinical Safety File pages).

### Key CSO decisions captured

- **IEC 62304 Class B** — no plausible death/serious-injury scenario from software failure (multiple independent clinical safeguards), but not risk-free (not Class A).
- **ISO 14971 via mapping**, not re-framing — DCB0129 scales retained.
- **Intended Purpose** extracted to a single canonical source.

### Validation
- `codespell` — clean
- `pymarkdown` lint — clean
- `zensical build` — **"No issues found"**; all cross-document links **and heading anchors** verified against the generated HTML.

### Not in scope (future phases)
- Phase 4 — process formalisation: GitHub Issue templates, CODEOWNERS review gate, scheduled management review & internal-audit cycle.
- Phase 5 — EU MDR 2017/745 readiness; shared QMS template extraction; DCB0160 implementer starter template.