### PR TITLE
QMS Phase 4: process & governance formalisation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,18 @@
+# Code owners for the RCPCH Digital Growth Charts documentation.
+#
+# The Clinical Safety Officer / PRRC is the required reviewer for the clinical
+# safety, medical-device and quality-management documentation, and for the QMS
+# process configuration (issue templates, labels and this file).
+#
+# This auto-requests review from the owner on any matching change. Review is
+# *enforced* only when branch protection on `live` has "Require review from
+# Code Owners" enabled. See https://growth.rcpch.ac.uk/safety/qms/
+
+# Clinical safety, medical-device regulation and quality-management documents
+/docs/safety/                       @pacharanero
+
+# QMS process configuration
+/.github/CODEOWNERS                 @pacharanero
+/.github/labels.yml                 @pacharanero
+/.github/ISSUE_TEMPLATE/            @pacharanero
+/.github/workflows/                 @pacharanero

--- a/.github/ISSUE_TEMPLATE/audit-finding.md
+++ b/.github/ISSUE_TEMPLATE/audit-finding.md
@@ -1,0 +1,28 @@
+---
+name: "Audit Finding"
+about: "Record a single finding from an internal audit"
+title: "AUDIT FINDING: <short summary>"
+labels: audit-finding
+assignees:
+---
+Use this template to record a single finding arising from an [internal audit](https://growth.rcpch.ac.uk/safety/qms/#internal-audit). Link it to its parent **Internal Audit** issue.
+
+### Parent audit
+Link the Internal Audit issue this finding belongs to.
+
+### Clause / document reference
+Which ISO 13485 clause or controlled document does this relate to?
+
+### Finding
+What was found?
+
+### Evidence
+What evidence supports the finding?
+
+### Classification
+- [ ] Major non-conformity
+- [ ] Minor non-conformity
+- [ ] Observation / opportunity for improvement
+
+### Action
+Non-conformities must raise a **CAPA** — link it here. The finding is closed when the action is verified effective.

--- a/.github/ISSUE_TEMPLATE/capa.md
+++ b/.github/ISSUE_TEMPLATE/capa.md
@@ -1,0 +1,33 @@
+---
+name: "CAPA (Corrective and Preventive Action)"
+about: "Record a corrective and/or preventive action"
+title: "CAPA: <short summary>"
+labels: capa
+assignees:
+---
+Use this template to record a Corrective and Preventive Action, raised in response to a confirmed complaint indicating a systemic issue, an audit finding, a non-conformity, a serious incident, or an adverse trend. Part of the [Quality Management System](https://growth.rcpch.ac.uk/safety/qms/).
+
+### Trigger
+What gave rise to this CAPA? Link the originating complaint, audit finding, non-conformity, serious incident or hazard.
+
+### Description of the (potential) non-conformity
+What is the problem, or potential problem?
+
+### Root cause analysis
+Why did it happen?
+
+### Corrective action
+What will be done to fix the **current** problem?
+
+### Preventive action
+What will be done to prevent **recurrence**?
+
+### Owner and due date
+**Owner:** @  ·  **Due:** YYYY-MM-DD
+
+### Verification of effectiveness
+How will we know the action worked, and by when? Record the verification result here before closing.
+
+-----
+
+CAPAs are reviewed at [management review](https://growth.rcpch.ac.uk/safety/qms/#management-review). Overdue actions are escalated to the Clinical Safety Officer / PRRC @pacharanero.

--- a/.github/ISSUE_TEMPLATE/complaint.md
+++ b/.github/ISSUE_TEMPLATE/complaint.md
@@ -1,0 +1,31 @@
+---
+name: "Complaint / Feedback"
+about: "Record a complaint or item of feedback about the dGC Platform"
+title: "COMPLAINT: <short summary>"
+labels: complaint
+assignees:
+---
+Use this template to record any expression of dissatisfaction, or any report of a potential safety or quality issue, regardless of source. This supports the [Post-Market Surveillance](https://growth.rcpch.ac.uk/safety/csmf/pms-plan/) process of the [Quality Management System](https://growth.rcpch.ac.uk/safety/qms/).
+
+### Source
+Where did this come from? (public GitHub Issue, RCPCH forum, email, direct from an implementer, clinical incident, other)
+
+### Date received
+YYYY-MM-DD
+
+### Description
+What is the complaint or feedback?
+
+### Initial assessment
+Is this a potential clinical-safety issue? Could it be a reportable **serious incident**?
+
+> If it could be a serious incident, also open a **Serious Incident** issue and notify the Clinical Safety Officer @pacharanero immediately.
+
+### Investigation / root cause
+To be completed during investigation. Record findings here.
+
+### Action taken
+Link any resulting **CAPA**, **Hazard**, Pull Request or commit.
+
+### Resolution
+How was it resolved? Note any response provided to the complainant (if identified). Close the issue when resolved.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: RCPCH Digital Growth Charts forum
+    url: https://forum.rcpch.tech
+    about: Ask a question, request support, or discuss the dGC Platform with the team and community.
+  - name: Quality Management System
+    url: https://growth.rcpch.ac.uk/safety/qms/
+    about: Read how these issue types fit into the QMS before raising one.

--- a/.github/ISSUE_TEMPLATE/design-input.md
+++ b/.github/ISSUE_TEMPLATE/design-input.md
@@ -1,0 +1,29 @@
+---
+name: "Design Input"
+about: "Record a design input (requirement) for a new feature or significant change"
+title: "DESIGN INPUT: <short summary>"
+labels: design-input
+assignees:
+---
+Use this template at the start of any significant development effort (new feature, major change, new product) to record a formal design input, per the [Software Lifecycle (IEC 62304)](https://growth.rcpch.ac.uk/safety/csmf/software-lifecycle/) process of the [Quality Management System](https://growth.rcpch.ac.uk/safety/qms/).
+
+### Clinical or user need
+What clinical or user need drives this change?
+
+### Intended functionality
+What should the change do? Keep it unambiguous and verifiable.
+
+### Acceptance criteria
+How will we know the requirement has been met? (These become verification tests.)
+
+### Regulatory impact
+Does this affect any of the following? Note the impact and link the relevant document.
+
+- [ ] Intended Purpose
+- [ ] Device classification (UK MDR / IEC 62304 software class)
+- [ ] Risk management (new or changed Hazard)
+- [ ] Clinical Evaluation
+- [ ] Labelling / Instructions for Use
+
+### Review and approval
+Design inputs are reviewed and approved by the Technical Lead and Clinical Lead. Where regulatory impact is identified, the CSO / PRRC @pacharanero must also approve.

--- a/.github/ISSUE_TEMPLATE/internal-audit.md
+++ b/.github/ISSUE_TEMPLATE/internal-audit.md
@@ -1,0 +1,29 @@
+---
+name: "Internal Audit"
+about: "Plan and record an internal audit of the QMS"
+title: "INTERNAL AUDIT: <year / scope>"
+labels: internal-audit
+assignees:
+---
+Use this template to plan an internal audit verifying that the QMS conforms to ISO 13485:2016 and is effectively implemented. See [Internal audit](https://growth.rcpch.ac.uk/safety/qms/#internal-audit) in the Quality Management System.
+
+### Scope
+Which parts of the QMS / which ISO 13485 clauses are being audited?
+
+### Planned date
+YYYY-MM-DD
+
+### Auditor
+Who is conducting the audit? The auditor must be **independent of the area being audited**.
+
+### Clauses / documents to be covered
+List the clauses and controlled documents in scope.
+
+### Audit plan
+Link or summarise the audit plan.
+
+### Findings
+Record findings as separate **Audit Finding** issues, linked here. Non-conformities trigger a **CAPA**.
+
+### Closure
+The audit is closed when all findings are resolved. Confirmed by the CSO / PRRC @pacharanero.

--- a/.github/ISSUE_TEMPLATE/management-review.md
+++ b/.github/ISSUE_TEMPLATE/management-review.md
@@ -1,0 +1,36 @@
+---
+name: "Management Review"
+about: "Plan and record a periodic management review of the QMS"
+title: "MANAGEMENT REVIEW: <year>"
+labels: management-review
+assignees:
+---
+Use this template to plan and record a management review of the QMS, held at planned intervals to ensure its continuing suitability, adequacy and effectiveness (ISO 13485 §5.6). See [Management review](https://growth.rcpch.ac.uk/safety/qms/#management-review).
+
+### Date
+YYYY-MM-DD
+
+### Attendees
+Technical Lead, Clinical Lead, CSO / PRRC, others as required.
+
+### Inputs (agenda)
+Review each input and record the discussion / conclusion:
+
+- [ ] Status of actions from previous management reviews
+- [ ] Feedback and **complaints**
+- [ ] **Serious incidents** and MHRA vigilance reporting
+- [ ] Post-Market Surveillance findings and state-of-the-art review
+- [ ] Hazard Log / risk management status
+- [ ] **Internal audit** results and open **audit findings**
+- [ ] Open **CAPA**s (including overdue / overdue-escalated)
+- [ ] Supplier (SOUP / third-party) monitoring
+- [ ] Regulatory or standards changes
+- [ ] Status of **quality objectives**
+- [ ] Recommendations for improvement
+- [ ] Resource adequacy
+
+### Outputs (decisions and actions)
+Record decisions, improvement actions, resource needs and updated quality objectives. Raise follow-up actions as **CAPA** or **Design Input** issues and link them here.
+
+### Record
+This issue, once completed and closed, is the record of the management review.

--- a/.github/ISSUE_TEMPLATE/serious-incident.md
+++ b/.github/ISSUE_TEMPLATE/serious-incident.md
@@ -1,0 +1,32 @@
+---
+name: "Serious Incident"
+about: "Record a serious incident for assessment and possible MHRA vigilance reporting"
+title: "SERIOUS INCIDENT: <short summary>"
+labels: serious-incident
+assignees: pacharanero
+---
+Use this template to record any malfunction, deterioration in performance, or inadequacy in labelling or instructions for use, which **has led or could lead to** death, serious deterioration in health, or a serious public health threat. See the [incident process](https://growth.rcpch.ac.uk/safety/csmf/clinical-risk-mgmt-plan/#safety-incident-management-process) and the [PMS vigilance section](https://growth.rcpch.ac.uk/safety/csmf/pms-plan/#vigilance-reporting-to-the-mhra).
+
+> **Notify the Clinical Safety Officer / PRRC @pacharanero immediately.** Do not wait for the next sprint.
+
+### Date
+Date became aware: YYYY-MM-DD
+
+### Description
+What happened?
+
+### Patient / clinical impact
+Actual or potential harm.
+
+### Reportability assessment
+Is this reportable to the MHRA? Record the reasoning and the applicable timeline:
+
+- Serious public health threat — **2 calendar days**
+- Death or unanticipated serious deterioration in health — **10 calendar days**
+- Other serious incidents — **30 calendar days**
+
+### MHRA report reference
+Add the MHRA reference number once submitted.
+
+### Investigation, CAPA and outcome
+Link the investigation, any **CAPA**, Hazard Log updates and the final outcome.

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,4 +1,4 @@
-# This file contains definitions for the Hazard Log labels
+# This file contains definitions for the Hazard Log labels and the QMS process labels
 # Reference: DCB0129: Clinical Risk Management: its Application in the Manufacture of Health IT Systems
 # https://digital.nhs.uk/data-and-information/information-standards/information-standards-and-data-collections-including-extractions/publications-and-notifications/standards-and-collections/dcb0129-clinical-risk-management-its-application-in-the-manufacture-of-health-it-systems
 # Implementation Guidance https://digital.nhs.uk/binaries/content/assets/legacy/pdf/0129242018impguid.pdf
@@ -83,3 +83,50 @@
 - name: "risk-level-5-unacceptable"
   description: "Unacceptable level of risk"
   color: "B60205"
+
+# QMS process labels
+# Used by the GitHub Issue templates in .github/ISSUE_TEMPLATE/ to track the
+# quality-management processes described at https://growth.rcpch.ac.uk/safety/qms/
+- name: "complaint"
+  description: "A complaint or item of feedback about the dGC Platform (QMS feedback handling)."
+  color: "1D76DB"
+
+- name: "capa"
+  description: "A Corrective and/or Preventive Action."
+  color: "0052CC"
+
+- name: "serious-incident"
+  description: "A serious incident requiring assessment for MHRA vigilance reporting."
+  color: "D73A4A"
+
+- name: "design-input"
+  description: "A formal design input (requirement) for a feature or significant change."
+  color: "006B75"
+
+- name: "internal-audit"
+  description: "Planning and record of an internal audit of the QMS."
+  color: "5319E7"
+
+- name: "audit-finding"
+  description: "A single finding arising from an internal audit."
+  color: "F9D0C4"
+
+- name: "management-review"
+  description: "Planning and record of a periodic management review of the QMS."
+  color: "8B5CF6"
+
+- name: "non-conformity"
+  description: "A non-conformity against the QMS, a standard, or a requirement."
+  color: "E99695"
+
+- name: "quality-objective"
+  description: "A measurable quality objective and its status."
+  color: "C2E0C6"
+
+- name: "pms"
+  description: "Post-Market Surveillance activity, finding or trend."
+  color: "BFD4F2"
+
+- name: "regulatory"
+  description: "Regulatory or standards change relevant to the QMS or device."
+  color: "FEF2C0"

--- a/docs/safety/qms.md
+++ b/docs/safety/qms.md
@@ -71,12 +71,12 @@ All controlled documents — this manual, the clinical safety file, and the tech
 
 - Changes are proposed by **Pull Request** and require **at least one approving review** before merge to the protected `live` branch.
 - The **Git commit history is the complete, immutable change record** for every controlled document; history is not rewritten on `live`.
-- **Records** (hazards, incidents, complaints, decisions) are kept as GitHub Issues and commits and are retained indefinitely.
+- **Records** (hazards, incidents, complaints, CAPAs, audits and management reviews) are created from the [QMS Issue templates](https://github.com/rcpch/digital-growth-charts-documentation/tree/live/.github/ISSUE_TEMPLATE), identified by [QMS process labels](https://github.com/rcpch/digital-growth-charts-documentation/blob/live/.github/labels.yml), kept as GitHub Issues and commits, and retained indefinitely. Records are **public by default**; where a record would contain sensitive or patient-identifiable information (for example within a serious-incident investigation), that specific content is restricted and handled case by case.
 
 This replaces traditional manual document controls, as described in the [Clinical Risk Management Plan](csmf/clinical-risk-mgmt-plan.md#document-controls).
 
-!!! note "Planned formalisation"
-    A `CODEOWNERS` rule requiring PRRC review for safety- and regulatory-critical documents, and a set of QMS GitHub Issue templates (complaint, CAPA, design-input, serious-incident, audit, management-review, hazard), are planned as the next increment of QMS formalisation. The underlying controls — mandatory review on `live` and open Issue-based records — are already in force.
+!!! note "Process controls"
+    A [`CODEOWNERS`](https://github.com/rcpch/digital-growth-charts-documentation/blob/live/.github/CODEOWNERS) rule requests **PRRC review** for changes to the safety, regulatory and QMS-process files, and a set of [QMS Issue templates](https://github.com/rcpch/digital-growth-charts-documentation/tree/live/.github/ISSUE_TEMPLATE) — complaint, CAPA, design-input, serious-incident, internal-audit, audit-finding, management-review and hazard — gives each quality process a consistent, labelled record. The CODEOWNERS gate is *enforced* when branch protection on `live` has "Require review from Code Owners" enabled; in all cases it auto-requests the PRRC's review, and mandatory review on `live` is already in force.
 
 ## Design and development
 
@@ -94,16 +94,30 @@ Suppliers whose products could affect device quality, safety or availability are
 
 Feedback and complaints arrive through open GitHub Issues, the [RCPCH forum](https://forum.rcpch.tech), and direct implementer communication, and are handled under the [Post-Market Surveillance](csmf/pms-plan.md) plan. Serious incidents are assessed for MHRA reportability by the PRRC under the [incident process](csmf/clinical-risk-mgmt-plan.md#safety-incident-management-process). Clinical performance is appraised in the [Clinical Evaluation Report](csmf/clinical-evaluation.md).
 
+## Scheduled QMS activities
+
+The QMS runs to a defined rhythm. Each recurring activity has an owner and a record; the records are GitHub Issues raised from the corresponding [Issue template](https://github.com/rcpch/digital-growth-charts-documentation/tree/live/.github/ISSUE_TEMPLATE).
+
+| Activity | Frequency | Owner | Record |
+| -------- | --------- | ----- | ------ |
+| Management review | At least annually, and after any significant quality event | CSO / PRRC | Management Review Issue |
+| Internal audit | At least annually | QMS Administrator (independent of the area audited) | Internal Audit + Audit Finding Issues |
+| Supplier / SOUP review | At least annually, and on any supplier change | Technical Lead | [Third Party Tools register](csmf/third-party-tools-safety-assmt.md) + management review |
+| Hazard Log review | Every release, and on any new or changed hazard | CSO / PRRC | Hazard Issues; [Clinical Safety Case Report](csmf/clinical-safety-case-report.md) |
+| Post-Market Surveillance review | Continuous, formally appraised at each management review | CSO / PRRC | [PMS plan](csmf/pms-plan.md) + management review |
+| CAPA review | Continuous; status reviewed at each management review | CSO / PRRC | CAPA Issues |
+| Quality-objectives review | At each management review | CSO / PRRC | Management Review Issue |
+
 ## Management review
 
-A formal management review is conducted at least **annually**, and following any significant quality event. It reviews the quality policy and objectives, audit findings, complaints and PMS data, supplier status, regulatory changes, and actions from the previous review.
+A formal management review is conducted at least **annually**, and following any significant quality event. It reviews the quality policy and objectives, audit findings, complaints and PMS data, supplier status, regulatory changes, open CAPAs, and actions from the previous review. Each review is planned and recorded using the [Management Review Issue template](https://github.com/rcpch/digital-growth-charts-documentation/blob/live/.github/ISSUE_TEMPLATE/management-review.md), whose agenda enumerates the ISO 13485 §5.6 inputs; the completed, closed Issue is the record of the review, and follow-up actions are raised as CAPA or design-input Issues.
 
 !!! note "First management review"
     A management review has not yet been formally conducted; the **first is planned**, and this QMS manual is being prepared for presentation to it.
 
 ## Internal audit
 
-Internal audit verifies that the QMS conforms to ISO 13485 and is effectively implemented. The RCPCH already audits its software and quality process on an ongoing, informal basis (for example through continuous open code review and the static test harness); this manual **formalises that practice** into a documented annual audit cycle, with findings recorded as GitHub Issues and non-conformities driving corrective action.
+Internal audit verifies that the QMS conforms to ISO 13485 and is effectively implemented. The RCPCH already audits its software and quality process on an ongoing, informal basis (for example through continuous open code review and the static test harness); this manual **formalises that practice** into a documented annual audit cycle. Each audit is planned with the [Internal Audit Issue template](https://github.com/rcpch/digital-growth-charts-documentation/blob/live/.github/ISSUE_TEMPLATE/internal-audit.md) and conducted by someone independent of the area audited; each finding is recorded with the [Audit Finding template](https://github.com/rcpch/digital-growth-charts-documentation/blob/live/.github/ISSUE_TEMPLATE/audit-finding.md), and non-conformities drive a CAPA to resolution.
 
 ## ISO 13485:2016 clause mapping
 
@@ -112,11 +126,11 @@ Internal audit verifies that the QMS conforms to ISO 13485 and is effectively im
 | 4.1 General QMS requirements | This page |
 | 4.2.1–4.2.2 Documentation / quality manual | This page |
 | 4.2.3 Medical device file | [Technical Documentation](medical-device-reg/mdr-technical-docs.md), [Essential Requirements](medical-device-reg/essential-req.md) |
-| 4.2.4 Document control | [Document and record control](#document-and-record-control); branch protection on `live` |
-| 4.2.5 Record control | GitHub Issues; Git commit history |
+| 4.2.4 Document control | [Document and record control](#document-and-record-control); branch protection and `CODEOWNERS` review gate on `live` |
+| 4.2.5 Record control | GitHub Issues (QMS templates + process labels); Git commit history |
 | 5.1 / 5.3 Management commitment & quality policy | [Quality policy and objectives](#quality-policy-and-objectives) |
 | 5.2 Customer focus | [Post-Market Surveillance](csmf/pms-plan.md) |
-| 5.4 Planning | [Quality objectives](#quality-policy-and-objectives); management review |
+| 5.4 Planning | [Quality objectives](#quality-policy-and-objectives); [Scheduled QMS activities](#scheduled-qms-activities) |
 | 5.5 Responsibility & authority | [Organisational roles](#organisational-roles) |
 | 5.6 Management review | [Management review](#management-review) |
 | 6.2 Human resources | [Competence and training](#competence-and-training) |
@@ -133,7 +147,7 @@ Internal audit verifies that the QMS conforms to ISO 13485 and is effectively im
 | 8.2.6 Monitoring & measurement of product | Static test harness; [Software Lifecycle](csmf/software-lifecycle.md#verification-and-validation-summary) |
 | 8.3 Control of nonconforming product | CI test gates; [incident process](csmf/clinical-risk-mgmt-plan.md#safety-incident-management-process) |
 | 8.4 Analysis of data | [PMS plan](csmf/pms-plan.md); management review |
-| 8.5 Improvement (CAPA) | [PMS plan](csmf/pms-plan.md); management review |
+| 8.5 Improvement (CAPA) | [PMS plan](csmf/pms-plan.md); CAPA Issues; management review |
 
 ## Review of this manual
 


### PR DESCRIPTION
## QMS Phase 4 — process & governance formalisation

Turns the *"planned formalisation"* note in the [QMS manual](../blob/qms-phase4-process-governance/docs/safety/qms.md) into working GitHub controls, completing the process/governance layer of the ISO 13485 hardening roadmap.

### What's in here

**Issue templates** (`.github/ISSUE_TEMPLATE/`) — matching the existing hazard-template style (frontmatter + `###` sections, `@pacharanero` owner), each carrying its QMS process label:

- `complaint`, `capa`, `design-input`, `serious-incident`, `internal-audit`, `audit-finding`, `management-review`
- `config.yml` — keeps blank issues enabled; adds forum + QMS contact links.

**Labels** (`.github/labels.yml`) — new *QMS process labels* section: `complaint`, `capa`, `serious-incident`, `design-input`, `internal-audit`, `audit-finding`, `management-review`, `non-conformity`, `quality-objective`, `pms`, `regulatory`.

**CODEOWNERS** — requests PRRC (`@pacharanero`) review for `docs/safety/` and the QMS process configuration.

**Quality manual** (`docs/safety/qms.md`):
- *"Planned formalisation"* note → *"Process controls"* describing the now-existing CODEOWNERS gate + templates.
- New **Scheduled QMS activities** table (management review, internal audit, supplier/SOUP review, hazard-log review, PMS review, CAPA review).
- Management-review and internal-audit sections reference their templates/records; records clarified as public-by-default with sensitive content restricted case by case.
- ISO 13485 clause map updated.

### Stacking & merge order

This PR is **stacked on `qms-phase3-iso-iec-alignment` (#168)** because it edits `docs/safety/qms.md`, which only exists on that branch — basing here keeps the diff clean. GitHub will auto-retarget this PR to `live` once #168 merges and its branch is deleted.

Recommended merge order: **#166 → #167 → #168 → this PR**.

### 🔧 Maintainer hand-off (post-merge)

- Run the **`create-hazard-log-labels.yml`** workflow (Actions → *Run workflow*) to apply the new QMS process labels. It is additive (`skip-delete: true`).
- *(Optional)* In branch protection for `live`, enable **"Require review from Code Owners"** to enforce the CODEOWNERS gate (it auto-requests review either way).

### Validation

- `codespell` clean on all new/changed files.
- `pymarkdown` clean on `docs/safety/qms.md`; templates intentionally follow the existing GitHub `###` template convention (out of the linted docs scope).
- `zensical build` → *No issues found*; new `#scheduled-qms-activities` anchor and all cross-links verified in generated HTML.
- `labels.yml` and all template frontmatter validated (no duplicate labels; every template label exists).